### PR TITLE
v0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,29 @@ service.LanguagePreferenceManager
 =================================
 
 A manager for audio and subtitle preferences
+============================================
+
+This addon provides an easy way to set your preferred audio stream and subtitle language in Kodi Matrix.
+
+You can select which audio tracks and subtitles to automatically activate based on your priorities, and define simple conditional rules like "if audio is xxx then activate subtitles yyy" via drop/down lists.
+More advanced custom rules can be defined as well (see changelog for more on the syntax. Note that custom rules always take precedence over others).
+
+Special language codes None(non) for subtitles and Any(any) for audio can be used in Conditional Subtitles Rules, normal or custom.
+For example "fre:non>any:fre>any:eng" will disable subtitles if audio is French (except if a french forced subtitles track exists) and activate french subtitles for any other audio language. If these are not available it will try the same finding english subtitles.
+
+Rules are re-evaluated and applied whenever you switch audio while watching (from v0.1.5).
+
+It's now also possible to force ignore "Signs and Songs" subtitles in preferences evaluations, based on name.
+
+For example, most dual audio Anime provides english and japanese audio and two english subtitles. Dialogue subtitles with all the dialogue to go with the japanese audio and Song/Sign subtitles which only translate song lyrics and signs you see on screen to be used with the english audio stream. Previously the addon just picked the first subtitles with the correct language which weren't always the correct ones.
+
+Special Thanks
+==============
+
+- @ace20022 and @scott967 for initial development
+
+- @cyberden for making this addon ready for Kodi Matrix
+
+- @fpatrick for fixing an issue with language mapping
+
+- @KnappeGEIL for ideas how to ignore 'Signs and Songs' subtitles

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="0.1.5"
+	version="0.1.6BETA"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -17,9 +17,10 @@
 		<description lang="en_GB">Sets the audio and subtitle track according to your language preferences</description>
 		<disclaimer lang="en_GB">For bugs, requests or general questions visit the Language Preference Manager thread on the Kodi forum.</disclaimer>
 		<platform>all</platform>
-		<news>1.0.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
-1.0.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
-1.0.5     : Some minor optimisation</news>
+		<news>0.1.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
+0.1.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
+0.1.5     : Some minor optimisation
+0.1.6BETA : Fix Custom Condsub not working</news>
 		<assets>
 			<icon>resources/icon.png</icon>
 		</assets>

--- a/addon.xml
+++ b/addon.xml
@@ -20,7 +20,7 @@
 		<news>0.1.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
 0.1.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
 0.1.5     : Some minor optimisation
-0.1.6BETA : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Fix some typos</news>
+0.1.6BETA : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Add special 'Any' audio language code. Fix some typos</news>
 		<assets>
 			<icon>resources/icon.png</icon>
 		</assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="0.1.6BETA"
+	version="0.1.6"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -20,7 +20,7 @@
 		<news>0.1.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
 0.1.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
 0.1.5     : Some minor optimisation
-0.1.6BETA : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Add special 'Any' audio language code. Fix some typos</news>
+0.1.6     : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Add special 'Any' audio language code. Fix some typos</news>
 		<assets>
 			<icon>resources/icon.png</icon>
 		</assets>

--- a/addon.xml
+++ b/addon.xml
@@ -20,7 +20,7 @@
 		<news>0.1.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
 0.1.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
 0.1.5     : Some minor optimisation
-0.1.6BETA : Fix Custom Condsub not working</news>
+0.1.6BETA : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Fix some typos</news>
 		<assets>
 			<icon>resources/icon.png</icon>
 		</assets>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+--- Version 0.1.6BETA
+
+- Fix custom conditional preferences rules not working. (note : if ...>lan:non>... is used then forced tag is assumed on. See v0.1.3)
+- Add a switch to completely ignore 'Signs and Songs' types of subtitle tracks. Default is off.
+- Plus some small typo fixed.
+
 --- Version 0.1.5
 
 - Fix preferences rules numbering in log messages.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 - Fix custom conditional preferences rules not working. (note : if ...>lan:non>... is used then forced tag is assumed on. See v0.1.3)
 - Add a switch to completely ignore 'Signs and Songs' types of subtitle tracks. Default is off.
+- Add special 'Any' audio language code to allow easy / simplified Conditional Subtitles rules like 'pol:non>any:pol'.
 - Plus some small typo fixed.
 
 --- Version 0.1.5

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
---- Version 0.1.6BETA
+--- Version 0.1.6
 
 - Fix custom conditional preferences rules not working. (note : if ...>lan:non>... is used then forced tag is assumed on. See v0.1.3)
 - Add a switch to completely ignore 'Signs and Songs' types of subtitle tracks. Default is off.

--- a/default.py
+++ b/default.py
@@ -255,6 +255,9 @@ class LangPrefMan_Player(xbmc.Player) :
                             return -1
                     else:
                         for sub in self.subtitles:
+                            if (settings.ignore_signs_on and self.isSignsSub(sub['name'])):
+                                log(LOG_INFO,'SubPrefs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
+                                continue
                             if ((code == sub['language'] or name == sub['language']) and self.testForcedFlag(forced, sub['name'])):
                                 log(LOG_INFO, 'Subtitle language of subtitle {0} matches preference {1} ({2})'.format(sub['index'], i, name) )
                                 return sub['index']
@@ -304,6 +307,9 @@ class LangPrefMan_Player(xbmc.Player) :
                             return -1
                         else:
                             for sub in self.subtitles:
+                                if (settings.ignore_signs_on and self.isSignsSub(sub['name'])):
+                                    log(LOG_INFO,'CondSubs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
+                                    continue
                                 if ((sub_code == sub['language']) or (sub_name == sub['language'])):
                                     if (self.testForcedFlag(forced, sub['name'])):
                                         log(LOG_INFO, 'Language of subtitle {0} matches conditional preference {1} ({2}:{3}) forced {4}'.format(sub['index'], i, audio_name, sub_name, forced) )
@@ -311,7 +317,12 @@ class LangPrefMan_Player(xbmc.Player) :
                             log(LOG_INFO, 'Conditional subtitle: no match found for preference {0} ({1}:{2})'.format(i, audio_name, sub_name) )
                 i += 1
         return -2
-   
+
+    def isSignsSub(self, subName):
+        test = subName.lower()
+        matches = ['signs']
+        return any(x in test for x in matches)
+    
     def testForcedFlag(self, forced, subName):
         test = subName.lower()
         matches = ['forced', 'forcés']

--- a/default.py
+++ b/default.py
@@ -290,7 +290,7 @@ class LangPrefMan_Player(xbmc.Player) :
 
                 if (self.selected_audio_stream and
                     'language' in self.selected_audio_stream and
-                    (audio_code == self.selected_audio_stream['language'] or audio_name == self.selected_audio_stream['language'])):
+                    (audio_code == self.selected_audio_stream['language'] or audio_name == self.selected_audio_stream['language'] or audio_code == "any")):
                         log(LOG_INFO, 'Selected audio language matches conditional preference {0} ({1}:{2}), force tag is {3}'.format(i, audio_name, sub_name, forced) )
                         if (sub_code == "non"):
                             if (forced == 'true'):

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -299,4 +299,4 @@ msgstr ""
 
 msgctxt "#30300"
 msgid "Any"
-msgstr "
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -109,6 +109,10 @@ msgctxt "#30122"
 msgid "General"
 msgstr ""
 
+msgctxt "#30123"
+msgid "Ignore all Signs and Songs subtitles tracks"
+msgstr ""
+
 msgctxt "#30201"
 msgid "Albanian"
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -297,3 +297,6 @@ msgctxt "#30200"
 msgid "None"
 msgstr ""
 
+msgctxt "#30300"
+msgid "Any"
+msgstr "

--- a/resources/lib/langcodes.py
+++ b/resources/lib/langcodes.py
@@ -54,7 +54,8 @@ LANGUAGES      = (
     ("Turkish"                    , "30",       "tr",            "tur",                 "42",                    30243  ),
     ("Ukrainian"                  , "46",       "uk",            "ukr",                 "43",                    30244  ),
     ("Vietnamese"                 , "51",       "vi",            "vie",                 "44",                    30245  ),
-    ("None"                       , "-1",       "",              "non",                 "45",                    30200  ) )
+    ("None"                       , "-1",       "",              "non",                 "45",                    30200  ),
+    ("Any"                        , "-2",       "",              "any",                 "46",                    30300  ) )
 
 def languageTranslate(lang, lang_from, lang_to):
   for x in LANGUAGES:

--- a/resources/lib/prefparser.py
+++ b/resources/lib/prefparser.py
@@ -81,7 +81,8 @@ class PrefParser:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
-                        lang_prefs.append((temp_a[0], temp_a[1], temp_s[0], temp_s[1]))
+                        forced_tag = 'false'
+                        lang_prefs.append((temp_a[0], temp_a[1], temp_s[0], temp_s[1], forced_tag))
                     else:
                         self.log(LOG_INFO, 'Custom cond sub prefs: lang code not found in db!'\
                                  ' Please report this: {0}:{1}'.format(temp_a, temp_s))

--- a/resources/lib/prefparser.py
+++ b/resources/lib/prefparser.py
@@ -81,7 +81,10 @@ class PrefParser:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
-                        forced_tag = 'false'
+                        if (temp_s[1] == 'non'):
+                            forced_tag = 'true'
+                        else:
+                            forced_tag = 'false'
                         lang_prefs.append((temp_a[0], temp_a[1], temp_s[0], temp_s[1], forced_tag))
                     else:
                         self.log(LOG_INFO, 'Custom cond sub prefs: lang code not found in db!'\

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -49,6 +49,7 @@ class settings():
                  'subs on: {2}\n' \
                  'cond subs on: {3}\n' \
                  'turn subs on: {4}, turn subs off: {5}\n' \
+                 'signs: {15}\n' \
                  'use file name: {6}, file name regex: {7}\n' \
                  'at least one pref on: {8}\n'\
                  'audio prefs: {9}\n' \
@@ -62,7 +63,7 @@ class settings():
                          self.condsub_prefs_on, self.turn_subs_on, self.turn_subs_off,
                          self.useFilename, self.filenameRegex, self.at_least_one_pref_on,
                          self.AudioPrefs, self.SubtitlePrefs, self.CondSubtitlePrefs,
-                         self.custom_audio, self.custom_subs, self.custom_condsub)
+                         self.custom_audio, self.custom_subs, self.custom_condsub, self.ignore_signs_on)
                  )
       
     def readPrefs(self):
@@ -75,6 +76,7 @@ class settings():
       self.condsub_prefs_on = addon.getSetting('enableCondSub') == 'true'
       self.turn_subs_on = addon.getSetting('turnSubsOn') == 'true'
       self.turn_subs_off = addon.getSetting('turnSubsOff') == 'true'
+      self.ignore_signs_on = addon.getSetting('signs') == 'true'
       self.useFilename = addon.getSetting('useFilename') == 'true'
       self.filenameRegex = addon.getSetting('filenameRegex')
       if self.useFilename:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -730,7 +730,7 @@
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
-				<setting id="ConsSubLang03" type="integer" label="30111">
+				<setting id="CondSubLang03" type="integer" label="30111">
 					<default>11</default>
 					<constraints>
 						<options>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -51,6 +51,10 @@
 					<default>false</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="signs" label="30123" type="boolean">
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 			</group>
 		</category>
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -732,6 +732,7 @@
 							<option label="30244">43</option>
 							<option label="30245">44</option>
 							<option label="30200">45</option>
+							<option label="30300">46</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
@@ -786,7 +787,6 @@
 							<option label="30244">43</option>
 							<option label="30245">44</option>
 							<option label="30200">45</option>
-							<option label="30300">46</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -502,6 +502,7 @@
 							<option label="30244">43</option>
 							<option label="30245">44</option>
 							<option label="30200">45</option>
+							<option label="30300">46</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
@@ -616,6 +617,7 @@
 							<option label="30244">43</option>
 							<option label="30245">44</option>
 							<option label="30200">45</option>
+							<option label="30300">46</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
@@ -784,6 +786,7 @@
 							<option label="30244">43</option>
 							<option label="30245">44</option>
 							<option label="30200">45</option>
+							<option label="30300">46</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>


### PR DESCRIPTION
Fix custom conditional preferences rules not working. (note : if ...>lan:non>... is used then forced tag is assumed on. See v0.1.3)
Add a switch to completely ignore 'Signs and Songs' types of subtitle tracks. Default is off.
Add special 'Any' audio language code to allow easy / simplified Conditional Subtitles rules like 'pol:non>any:pol'.
Plus some small typo fixed.