### PR TITLE
Fix Language Code Conflict

### DIFF
--- a/resources/lib/prefparser.py
+++ b/resources/lib/prefparser.py
@@ -31,7 +31,6 @@ class PrefParser:
         self.custom_g_t_pref_delim = r'#'
         self.custom_g_t_delim = r','
         self.custom_condSub_delim = r':'
-        self.custom_subtag_delim = r'-'
         
     def parsePrefString(self, pref_string):
         preferences = []
@@ -81,17 +80,11 @@ class PrefParser:
                 else:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
                     # Searching if a sub tag is present (like Eng:Eng-ss to prioritize Signs&Songs tracks)
-                    ss_tag = 'false'
-                    if (pref[1].find(self.custom_subtag_delim) > 0):
-                        st_pref = pref[1].split(self.custom_subtag_delim)
-                        if len(st_pref) != 2:
-                            print('Custom cond subs prefs parse error: {0}'.format(pref))
-                        else:
-                            if (st_pref[1] == 'ss'):
-                                ss_tag = 'true'
-                            else:
-                                self.log(LOG_INFO, 'Custom cond subs prefs parse error: {0}. Unknown sub tag is ignored'.format(pref))
-                        pref[1] = st_pref[0]
+                    if pref[1].endswith('-ss'):
+                        ss_tag = 'true'
+                        pref[1] = pref[1].rstrip('-ss')
+                    else:
+                        ss_tag = 'false'
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
                         if (temp_s[1] == 'non'):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -245,7 +245,11 @@ class LangPrefMan_Player(xbmc.Player) :
 
             log(LOG_INFO,'Subtitle: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
-                name, codes, forced = pref
+                if len(pref) == 2:
+                    name, codes = pref
+                    forced = 'false'
+                else:
+                    name, codes, forced = pref
                 codes = codes.split(r',')
                 for code in codes:
                     if (code is None):


### PR DESCRIPTION
- Simplified the Signs&Songs identification/tagging by looking directly for the `-ss` string suffix instead of trying to split by `-` and then checking length and if the second element matches `ss`
- Added a length check to `parsePref()` since sets from the custom fields don't have the `forced` element, which raised an exception

Changes tested on 2-3 episodes, intended language selected and no more crashes ( Fixes #9 )

I refrained from formatting the code to keep the diff small and easy to read. Didn't work out all that well for the whole PR given the desync between `master` and the latest branch (`V1.0.3`) but at least 861dc783d53668bfdfaf97e2f730166cca541548 ended up small 😄.
If allowed I could add another commit to address it as there are a few stray spaces and the likes