### PR TITLE
Added option to store/override preference per media

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -31,7 +31,7 @@
             New Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
             Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
             Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
-1.0.4     : Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
+1.0.4     : Fix and simplify SignsSongs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
 			
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -24,8 +24,8 @@
 0.1.7BETA : New Keywords Blacklist to ignore chosen subtitles tracks based on name content.
 1.0.0     : Mandatory clean-up to propose as candidate version for Kodi.tv addons repository.
 1.0.1     : Initial version for main Kodi.tv addons repository
-1.0.2     : Forced sub tracks : check subtitle stream field "isforced" in addition to just field "name" which can be empty
-            Fix to avoid 10-15sec delay and few lines lost on subtitles at the very begining of a video
+1.0.2     : Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.
+            Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA2"
+	version="1.0.3BETA3"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -29,6 +29,7 @@
 1.0.3BETA1: Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
 				Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
 1.0.3BETA2: Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
+1.0.3BETA3: Fixed Greek language codes. Fix some typos.
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -17,12 +17,7 @@
 		<description lang="en_GB">Sets the audio and subtitle track according to your language preferences</description>
 		<disclaimer lang="en_GB">For bugs, requests or general questions visit the Language Preference Manager thread on the Kodi forum.</disclaimer>
 		<platform>all</platform>
-		<news>0.1.3     : Updated with changes required for Kodi 19 / Python 3 + Fixed Languages labels/tables, ConditionnalSubs to None, Custom settings
-0.1.4BETA : Conditional Subtitles rules are re-assessed on-the-fly when toggling audio tracks
-0.1.5     : Some minor optimisation
-0.1.6     : Fix Custom CondSubs not working. Switch to ignore 'Signs' tracks. Add special 'Any' audio language code. Fix some typos
-0.1.7BETA : New Keywords Blacklist to ignore chosen subtitles tracks based on name content.
-1.0.0     : Mandatory clean-up to propose as candidate version for Kodi.tv addons repository.
+		<news>1.0.0     : Mandatory clean-up to propose as candidate version for Kodi.tv addons repository.
 1.0.1     : Initial version for main Kodi.tv addons repository
 1.0.2     : Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.
             Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA6"
+	version="1.0.3"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -26,15 +26,12 @@
 1.0.1     : Initial version for main Kodi.tv addons repository
 1.0.2     : Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.
             Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.
-1.0.3BETA1: Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
-				Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
-1.0.3BETA2: Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
-1.0.3BETA3: Fixed Greek language codes. Fix some typos.
-1.0.3BETA4: Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
-1.0.3BETA5: Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
-            Fix Serbian language codes, now 'srp,scc' according to last iso639-2/T
-1.0.3BETA6: 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.
-
+1.0.3	  : Improve 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.
+            Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
+            New Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
+            Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
+            Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
+			
 		</news>
 		<assets>
 			<icon>resources/icon.png</icon>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA1"
+	version="1.0.3BETA2"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -28,6 +28,7 @@
             Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.
 1.0.3BETA1: Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
 				Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
+1.0.3BETA2: Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -27,7 +27,7 @@
             Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
             Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
 1.0.4     : Fix and simplify SignsSongs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
-1.0.5     : Add Norwegian Bokmal (nb,nob) and English Middle (enm) language codes according to ISO639-2.
+1.0.5     : Add Norwegian Bokmal (nb,nob), New Nowegian (nn,nno) and English Middle (enm) language codes according to ISO639-2.
             Clean-up some info/log message.
 			
 		</news>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.4"
+	version="1.0.5"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -27,6 +27,8 @@
             Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
             Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
 1.0.4     : Fix and simplify SignsSongs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
+1.0.5     : Add Norwegian Bokmal (nb,nob) and English Middle (enm) language codes according to ISO639-2.
+            Clean-up some info/log message.
 			
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA4"
+	version="1.0.3BETA5"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -31,6 +31,8 @@
 1.0.3BETA2: Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
 1.0.3BETA3: Fixed Greek language codes. Fix some typos.
 1.0.3BETA4: Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
+1.0.3BETA5: Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
+            Fix Serbian language codes, now 'srp,scc' according to last iso639-2/T
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.2"
+	version="1.0.3BETA1"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -26,6 +26,8 @@
 1.0.1     : Initial version for main Kodi.tv addons repository
 1.0.2     : Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.
             Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.
+1.0.3BETA1: Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
+				Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA5"
+	version="1.0.3BETA6"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -33,6 +33,7 @@
 1.0.3BETA4: Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
 1.0.3BETA5: Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
             Fix Serbian language codes, now 'srp,scc' according to last iso639-2/T
+1.0.3BETA6: 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3"
+	version="1.0.4"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -31,6 +31,7 @@
             New Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
             Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
             Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
+1.0.4     : Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
 			
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3BETA3"
+	version="1.0.3BETA4"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -30,6 +30,7 @@
 				Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
 1.0.3BETA2: Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
 1.0.3BETA3: Fixed Greek language codes. Fix some typos.
+1.0.3BETA4: Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
 
 		</news>
 		<assets>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.1"
+	version="1.0.2"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -24,6 +24,8 @@
 0.1.7BETA : New Keywords Blacklist to ignore chosen subtitles tracks based on name content.
 1.0.0     : Mandatory clean-up to propose as candidate version for Kodi.tv addons repository.
 1.0.1     : Initial version for main Kodi.tv addons repository
+1.0.2     : Forced sub tracks : check subtitle stream field "isforced" in addition to just field "name" which can be empty
+            Fix to avoid 10-15sec delay and few lines lost on subtitles at the very begining of a video
 
 		</news>
 		<assets>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+--- Version 1.0.4
+
+- Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
+
 --- Version 1.0.3
 
 - Improve 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,29 +1,12 @@
---- Version 1.0.3BETA6
+--- Version 1.0.3
 
-- 10sec subs latency workaround: new option to enable it at 'start only' or 'start+resume'. Default is disabled.
-    (fast multiple resumes can sometimes generate restart or freeze due to audio/video desynch)
-
---- Version 1.0.3BETA5
-
-- Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
-- Fix Serbian language codes, now 'srp,scc' according to last iso639-2/T
-
---- Version 1.0.3BETA4
-
-- Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
-
---- Version 1.0.3BETA3
-
-- Fixed Greek language codes. Fix some typos.
-
---- Version 1.0.3BETA2
-
-- Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, skip some (ex. Commentary, ...)
-
---- Version 1.0.3BETA1
-
+- Improve 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.
+   (fast multiple resumes could sometimes generate video restart or long freeze due to large audio/video desynch)
 - Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
-	Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
+   (Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used)
+- New Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
+- Fix Greek and Serbian language codes according to Iso639-2/T. Fix some typos.
+- Fix support of multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
 
 --- Version 1.0.2
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+--- Version 1.0.3BETA6
+
+- 10sec subs latency workaround: new option to enable it at 'start only' or 'start+resume'. Default is disabled.
+    (fast multiple resumes can sometimes generate restart or freeze due to audio/video desynch)
+
 --- Version 1.0.3BETA5
 
 - Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+--- Version 1.0.3BETA4
+
+- Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.
+
 --- Version 1.0.3BETA3
 
 - Fixed Greek language codes. Fix some typos.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+--- Version 1.0.3BETA2
+
+- Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, skip some (ex. Commentary, ...)
+
 --- Version 1.0.3BETA1
 
 - Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+--- Version 1.0.2
+
+- To identify forced sub tracks : check subtitle stream field "isforced" in addition to just field "name" which can be empty
+- Fix to avoid 10-15sec delay and few lines lost on subtitles showing at the very begining of a video
+
 --- Version 1.0.1
 
 - Initial version for main Kodi.tv addons repository

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+--- Version 1.0.3BETA1
+
+- Option to prioritize 'SignsSongs' tracks via custom conditional sub preferences. Syntax is ...>Eng:Eng-ss>...
+	Overrides general 'Ignore Signs and Songs toggle' or 'Blacklisting Signs via keyword', if ever used.
+
 --- Version 1.0.2
 
 - Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+--- Version 1.0.5
+
+- Add Norwegian Bokmal (nb,nob) and English Middle (enm) language codes according to ISO639-2.
+- Clean-up some info/log message.
+
 --- Version 1.0.4
 
 - Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+--- Version 1.0.3BETA3
+
+- Fixed Greek language codes. Fix some typos.
+
 --- Version 1.0.3BETA2
 
 - Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, skip some (ex. Commentary, ...)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+--- Version 1.0.3BETA5
+
+- Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
+- Fix Serbian language codes, now 'srp,scc' according to last iso639-2/T
+
 --- Version 1.0.3BETA4
 
 - Fix random video/audio freeze at resume due to previous "Fix 10sec latency". Rewrite it and add debug messages.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 --- Version 1.0.2
 
-- To identify forced sub tracks : check subtitle stream field "isforced" in addition to just field "name" which can be empty
-- Fix to avoid 10-15sec delay and few lines lost on subtitles showing at the very begining of a video
+- Fix 10sec latency on subs display and possible few lines lost - at video start or when switching audio.
+- Forced sub tracks : check also subtitle field "isforced" in case field "name" is empty or misspelled.
 
 --- Version 1.0.1
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 --- Version 1.0.5
 
-- Add Norwegian Bokmal (nb,nob) and English Middle (enm) language codes according to ISO639-2.
+- Add Norwegian Bokmal (nb,nob), New Nowegian (nn,nno) and English Middle (enm) language codes according to ISO639-2.
 - Clean-up some info/log message.
 
 --- Version 1.0.4

--- a/default.py
+++ b/default.py
@@ -54,11 +54,5 @@ class Main:
 
 if ( __name__ == "__main__" ):
     log(LOG_INFO, 'service {0} version {1} started'.format(__addonname__, __addonversion__))
-
-    # List current files in folder
-    log(LOG_DEBUG, "Current files in folder:")
-    for file in xbmcvfs.listdir(__user_data_path__)[1]:
-        log(LOG_INFO, file)
-
     main = Main()
     log(LOG_INFO, 'service {0} version {1} stopped'.format(__addonname__, __addonversion__))

--- a/default.py
+++ b/default.py
@@ -32,7 +32,7 @@ def log(level, msg):
         elif level == LOG_INFO:
             l = xbmc.LOGINFO
         elif level == LOG_DEBUG:
-            l = xbmc.LOGINFO
+            l = xbmc.LOGDEBUG
         xbmc.log("[Language Preference Manager]: " + str(msg), l)
 
 class Main:

--- a/default.py
+++ b/default.py
@@ -10,6 +10,7 @@ __addonname__ = __addon__.getAddonInfo('name')
 __addonPath__ = __addon__.getAddonInfo('path')
 __addonResourcePath__ = xbmcvfs.translatePath(os.path.join(__addonPath__, 'resources', 'lib'))
 __addonIconFile__ = xbmcvfs.translatePath(os.path.join(__addonPath__, 'icon.png'))
+__user_data_path__ = xbmcvfs.translatePath("special://profile/addon_data/service.languagepreferencemanager/")
 sys.path.append(__addonResourcePath__)
 
 from langcodes import *
@@ -31,7 +32,7 @@ def log(level, msg):
         elif level == LOG_INFO:
             l = xbmc.LOGINFO
         elif level == LOG_DEBUG:
-            l = xbmc.LOGDEBUG
+            l = xbmc.LOGINFO
         xbmc.log("[Language Preference Manager]: " + str(msg), l)
 
 class Main:
@@ -53,5 +54,11 @@ class Main:
 
 if ( __name__ == "__main__" ):
     log(LOG_INFO, 'service {0} version {1} started'.format(__addonname__, __addonversion__))
+
+    # List current files in folder
+    log(LOG_DEBUG, "Current files in folder:")
+    for file in xbmcvfs.listdir(__user_data_path__)[1]:
+        log(LOG_INFO, file)
+
     main = Main()
     log(LOG_INFO, 'service {0} version {1} stopped'.format(__addonname__, __addonversion__))

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -154,16 +154,25 @@ msgid "Start & Resume"
 msgstr ""
 
 msgctxt "#30135"
-msgid "Overrides"
+msgid "Stored Preferences"
 msgstr ""
 
 msgctxt "#30136"
-msgid "Store Override Movies"
+msgid "Store Pref. Movies"
 msgstr ""
 
 msgctxt "#30137"
-msgid "Store Override TV Shows"
+msgid "Store Pref. TV Shows"
 msgstr ""
+
+msgctxt "#30138"
+msgid "Changed audio/subt. override config pref. next time for the same movie/series?"
+msgstr ""
+
+msgctxt "#30139"
+msgid "If enabled, manually selected audio/subtitle tracks during playback will be stored and restored next time for the same movie/whole series."
+msgstr ""
+
 
 msgctxt "#30201"
 msgid "Albanian"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -115,43 +115,55 @@ msgstr ""
 
 msgctxt "#30125"
 msgid "Enable Subtitle Keyword Blacklist"
-msgstr "
+msgstr ""
 
 msgctxt "#30126"
 msgid "Enter a comma-separated list of keywords to blacklist in subtitle names"
-msgstr "
+msgstr ""
 
 msgctxt "#30127"
 msgid "Subtitle Keyword List:"
-msgstr "
+msgstr ""
 
 msgctxt "#30128"
 msgid "Enable Audio Keyword Blacklist"
-msgstr "
+msgstr ""
 
 msgctxt "#30129"
 msgid "Enter a comma-separated list of keywords to blacklist in audio names"
-msgstr "
+msgstr ""
 
 msgctxt "#30130"
 msgid "Audio Keyword List:"
-msgstr "
+msgstr ""
 
 msgctxt "#30131"
 msgid "Fast Subtitles Display:"
-msgstr "
+msgstr ""
 
 msgctxt "#30132"
 msgid "Disabled"
-msgstr "
+msgstr ""
 
 msgctxt "#30133"
 msgid "New Start only"
-msgstr "
+msgstr ""
 
 msgctxt "#30134"
 msgid "Start & Resume"
-msgstr "
+msgstr ""
+
+msgctxt "#30135"
+msgid "Overrides"
+msgstr ""
+
+msgctxt "#30136"
+msgid "Store Override Movies"
+msgstr ""
+
+msgctxt "#30137"
+msgid "Store Override TV Shows"
+msgstr ""
 
 msgctxt "#30201"
 msgid "Albanian"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -137,6 +137,22 @@ msgctxt "#30130"
 msgid "Audio Keyword List:"
 msgstr "
 
+msgctxt "#30131"
+msgid "Fast Subtitles Display:"
+msgstr "
+
+msgctxt "#30132"
+msgid "Disabled"
+msgstr "
+
+msgctxt "#30133"
+msgid "New Start only"
+msgstr "
+
+msgctxt "#30134"
+msgid "Start & Resume"
+msgstr "
+
 msgctxt "#30201"
 msgid "Albanian"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -341,6 +341,10 @@ msgctxt "#30249"
 msgid "Norwegian Bokmal"
 msgstr ""
 
+msgctxt "#30250"
+msgid "New Norwegian"
+msgstr ""
+
 msgctxt "#30200"
 msgid "None"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -114,7 +114,7 @@ msgid "Ignore all Signs and Songs subtitles tracks"
 msgstr ""
 
 msgctxt "#30125"
-msgid "Enable Keyword Blacklist"
+msgid "Enable Subtitle Keyword Blacklist"
 msgstr "
 
 msgctxt "#30126"
@@ -122,7 +122,19 @@ msgid "Enter a comma-separated list of keywords to blacklist in subtitle names"
 msgstr "
 
 msgctxt "#30127"
-msgid "Keyword List:"
+msgid "Subtitle Keyword List:"
+msgstr "
+
+msgctxt "#30128"
+msgid "Enable Audio Keyword Blacklist"
+msgstr "
+
+msgctxt "#30129"
+msgid "Enter a comma-separated list of keywords to blacklist in audio names"
+msgstr "
+
+msgctxt "#30130"
+msgid "Audio Keyword List:"
 msgstr "
 
 msgctxt "#30201"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -333,6 +333,14 @@ msgctxt "#30245"
 msgid "Vietnamese"
 msgstr ""
 
+msgctxt "#30248"
+msgid "English Middle"
+msgstr ""
+
+msgctxt "#30249"
+msgid "Norwegian Bokmal"
+msgstr ""
+
 msgctxt "#30200"
 msgid "None"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -70,11 +70,11 @@ msgid "Delay the evaluation by the following value [ms]"
 msgstr ""
 
 msgctxt "#30113"
-msgid "Turn on subtitles if a subtitle prefrence matched"
+msgid "Turn on subtitles if a subtitle preference matched"
 msgstr ""
 
 msgctxt "#30114"
-msgid "Turn off subtitles if no subtitle prefrence matched"
+msgid "Turn off subtitles if no subtitle preference matched"
 msgstr ""
 
 msgctxt "#30115"

--- a/resources/lib/custom_media_preference.py
+++ b/resources/lib/custom_media_preference.py
@@ -107,7 +107,7 @@ class MediaPreferenceManager:
         for preference_json in json:
             custom_media_preferences.add_preference(CustomMediaPreference.from_json(preference_json))
 
-        log(LOG_INFO, "Loaded " + str(len(custom_media_preferences.preferences)) + " custom media preferences")
+        log(LOG_DEBUG, "Loaded " + str(len(custom_media_preferences.preferences)) + " custom media preferences")
 
         return custom_media_preferences
 

--- a/resources/lib/custom_media_preference.py
+++ b/resources/lib/custom_media_preference.py
@@ -1,0 +1,295 @@
+from logger import log, LOG_INFO, LOG_DEBUG, LOG_ERROR
+import xbmcvfs
+import json as simplejson
+
+__user_data_path__ = xbmcvfs.translatePath("special://profile/addon_data/service.languagepreferencemanager/")
+
+from resources.lib import kodi_utils
+
+
+class MediaPreferenceManager:
+
+    def __init__(self):
+        self.preferences = []
+
+    def add_preference(self, custom_media_preference):
+        if not isinstance(custom_media_preference, CustomMediaPreference):
+            log(LOG_ERROR, "Cannot add non-custom media preference")
+            return
+
+        if not custom_media_preference:
+            log(LOG_ERROR, "Cannot add empty custom media preference")
+            return
+
+        matching_preference = self.get_matching_preference(custom_media_preference)
+        if matching_preference is not None:
+            self.remove_preference(matching_preference)
+
+        self.preferences.append(custom_media_preference)
+
+    def remove_preference(self, custom_media_preference):
+        if self.has_preference(custom_media_preference):
+            self.preferences.remove(custom_media_preference)
+
+    def has_preference(self, custom_media_preference):
+        """
+        Check if the custom media preference is already in the list of preferences. That is, if the same media selector is already in the list.
+        :param custom_media_preference: The custom media preference to check
+        :return: True if the custom media preference is already in the list, False otherwise
+        """
+        return self.get_matching_preference(custom_media_preference) is not None
+
+    def get_matching_preference(self, custom_media_preference):
+        """
+        Get the custom media preference that matches the media selector of the given custom media preference. If no preference matches, return None.
+        :param custom_media_preference: The custom media preference to match
+        :return: The custom media preference that matches the media selector of the given custom media preference, or None if no preference matches
+        """
+        for preference in self.preferences:
+            if preference.selector.is_same_media(custom_media_preference.selector):
+                return preference
+
+        return None
+
+    def get_preference(self, player):
+        """
+        Get the custom media preference that applies to the playing item with the highest priority. If no preference applies, return None.
+        e.g. If two preferences apply to the playing item, the one with the highest priority will be returned.
+        :param player: The player to get the custom media preference for
+        :return:  The custom media preference that applies to the playing item with the highest priority, or None if no preference applies
+        """
+
+        applicable_preferences = []
+
+        for preference in self.preferences:
+            log(LOG_DEBUG, "Checking preference: " + preference.selector.to_string())
+            if preference.selector.applies_to_player(player):
+                applicable_preferences.append(preference)
+
+        if len(applicable_preferences) == 0:
+            return None
+
+        return max(applicable_preferences, key=lambda preference: preference.priority_index)
+
+    def save_preferences(self):
+        file_name = __user_data_path__ + "customMediaPreferences.json"
+
+        with open(file_name, 'w') as file:
+            file.write(simplejson.dumps(self.to_json(), indent=4))
+
+    @staticmethod
+    def from_file():
+        file_name = __user_data_path__ + "customMediaPreferences.json"
+        if xbmcvfs.exists(file_name):
+            log(LOG_DEBUG, "Attempting custom media preferences from file")
+
+            with open(file_name, 'r') as file:
+                # Check if file is empty
+                if not file.read(1):
+                    log(LOG_DEBUG, "No custom media preferences found (empty file?)")
+                    return
+
+                file.seek(0)
+
+                try:
+                    return MediaPreferenceManager.from_json(simplejson.loads(file.read()))
+                except Exception as e:
+                    log(LOG_ERROR, "Failed to load custom media preferences: " + str(e))
+
+        return MediaPreferenceManager()
+
+    def to_json(self):
+        return [preference.to_json() for preference in self.preferences]
+
+    @staticmethod
+    def from_json(json):
+        custom_media_preferences = MediaPreferenceManager()
+        for preference_json in json:
+            custom_media_preferences.add_preference(CustomMediaPreference.from_json(preference_json))
+
+        log(LOG_INFO, "Loaded " + str(len(custom_media_preferences.preferences)) + " custom media preferences")
+
+        return custom_media_preferences
+
+
+class CustomMediaPreference:
+
+    def __init__(self):
+        self.selector = None
+        self.priority_index = 0
+        self.audio_language = ""
+        self.audio_track_id = -1
+        self.subtitle_language = ""
+        self.subtitle_track_id = -1
+        self.enable_subtitles = False
+
+    def apply_to_player(self, player):
+        if not player.isPlayingVideo():
+            return
+
+        if self.audio_language or self.audio_track_id != -1:
+            audio_track_index = self.get_audio_track_index(player)
+            if audio_track_index is not None:
+                player.setAudioStream(audio_track_index)
+
+        if self.subtitle_language or self.subtitle_track_id != -1:
+            subtitle_track_index = self.get_subtitle_track_index(player)
+            if subtitle_track_index is not None:
+                if self.enable_subtitles:
+                    player.setSubtitleStream(subtitle_track_index)
+                player.showSubtitles(self.enable_subtitles)
+
+    def get_audio_track_index(self, player):
+        for stream in player.audiostreams:
+            if self.audio_language:
+                if 'language' in stream and stream['language'] == self.audio_language:
+                    return stream['index']
+            if self.audio_track_id != -1:
+                log(LOG_DEBUG,
+                    "Failed to find audio track by language " + self.audio_language + " for file " + player.getPlayingFile() + ". Trying by index")
+                if self.audio_track_id < len(player.audiostreams):
+                    return self.audio_track_id
+                else:
+                    log(LOG_ERROR, "Audio track id " + str(
+                        self.audio_track_id) + " is out of range for file " + player.getPlayingFile())
+
+        return None
+
+    def get_subtitle_track_index(self, player):
+        for subtitle in player.subtitles:
+            if self.subtitle_language:
+                if subtitle['language'] == self.subtitle_language:
+                    return subtitle['index']
+            if self.subtitle_track_id != -1:
+                log(LOG_DEBUG,
+                    "Failed to find subtitle track by language " + self.subtitle_language + " for file " + player.getPlayingFile() + ". Trying by index")
+                if self.subtitle_track_id < len(player.subtitles):
+                    return self.subtitle_track_id
+                else:
+                    log(LOG_ERROR, "Subtitle track id " + str(
+                        self.subtitle_track_id) + " is out of range for file " + player.getPlayingFile())
+        return
+
+    def to_json(self):
+        selector_string = ""
+
+        if self.selector:
+            selector_string = self.selector.to_string()
+
+        return {
+            "selector": selector_string,
+            "priority": self.priority_index,
+            "audio_language": self.audio_language,
+            "audio_track_id": self.audio_track_id,
+            "subtitle_language": self.subtitle_language,
+            "subtitle_track_id": self.subtitle_track_id,
+            "enable_subtitles": self.enable_subtitles
+        }
+
+    @staticmethod
+    def from_json(json):
+        custom_media_preference = CustomMediaPreference()
+        custom_media_preference.selector = MediaSelector.from_string(json["selector"])
+        custom_media_preference.priority_index = json["priority"]
+        custom_media_preference.audio_language = json["audio_language"]
+        custom_media_preference.audio_track_id = json["audio_track_id"]
+        custom_media_preference.subtitle_language = json["subtitle_language"]
+        custom_media_preference.subtitle_track_id = json["subtitle_track_id"]
+        custom_media_preference.enable_subtitles = json["enable_subtitles"]
+        return custom_media_preference
+
+    @staticmethod
+    def from_player(player):
+        if not player.isPlayingVideo():
+            return None
+
+        custom_media_preference = CustomMediaPreference()
+        custom_media_preference.selector = MediaSelector.from_playing_item(player)
+
+        custom_media_preference.audio_language = player.getSelectedAudioLanguage()
+        custom_media_preference.audio_track_id = player.getSelectedAudioIndex()
+        custom_media_preference.subtitle_language = player.getSelectedSubtitleLanguage()
+        custom_media_preference.subtitle_track_id = player.getSelectedSubtitleIndex()
+        custom_media_preference.enable_subtitles = player.selected_sub_enabled
+
+        return custom_media_preference
+
+class MediaSelector:
+
+    def __init__(self):
+        self.tv_show_name = ""
+        self.file_name = ""
+
+    def applies_to_player(self, player):
+        if not player:
+            return False
+
+        if not player.isPlayingVideo():
+            log(LOG_DEBUG, 'Player is not playing video, cannot apply media selector')
+            return False
+
+        playing_item = player.getPlayingItem()
+
+        if not playing_item:
+            log(LOG_DEBUG, 'No playing item found, cannot apply media selector')
+            return
+
+        video_info_tag = playing_item.getVideoInfoTag()
+
+        if not video_info_tag:
+            log(LOG_DEBUG, 'No video info tag found, cannot apply media selector')
+            return
+
+        is_tv_show = kodi_utils.is_tv_show(video_info_tag.getMediaType())
+        log(LOG_DEBUG, 'Media Info: ' + video_info_tag.getMediaType() + " is_tv_show: " + str(is_tv_show))
+
+        if is_tv_show and self.tv_show_name:
+            log(LOG_DEBUG, 'Checking TV Show name: ' + self.tv_show_name + ' against ' + video_info_tag.getTVShowTitle())
+            return video_info_tag.getTVShowTitle() == self.tv_show_name
+        elif self.file_name:
+            log(LOG_DEBUG, 'Checking file name: ' + self.file_name + ' against ' + player.getPlayingFile())
+            return player.getPlayingFile() == self.file_name
+        else:
+            return False
+
+    def to_string(self):
+        if self.tv_show_name:
+            return "tv_show:" + self.tv_show_name
+        elif self.file_name:
+            return "file:" + self.file_name
+        else:
+            return "unknown"
+
+    def is_same_media(self, media_selector):
+        return self.to_string() == media_selector.to_string()
+
+    @staticmethod
+    def from_string(s):
+        if not s:
+            return None
+
+        media_info = MediaSelector()
+        if s.startswith("tv_show:"):
+            media_info.tv_show_name = s[8:]
+        elif s.startswith("file:"):
+            media_info.file_name = s[5:]
+        return media_info
+
+    @staticmethod
+    def from_playing_item(player):
+        media_selector = MediaSelector()
+        playing_item = player.getPlayingItem()
+
+        video_info_tag = playing_item.getVideoInfoTag()
+
+        if not video_info_tag:
+            log(LOG_ERROR, 'No video info tag found, cannot create media selector')
+            return
+
+        media_selector.tv_show_name = video_info_tag.getTVShowTitle()
+        media_selector.file_name = player.getPlayingFile()
+
+        return media_selector
+
+
+media_preference_manager = MediaPreferenceManager.from_file()

--- a/resources/lib/kodi_utils.py
+++ b/resources/lib/kodi_utils.py
@@ -1,0 +1,38 @@
+
+
+def is_tv_show(media_type_str):
+    """
+    Check if the media type is a tv show. Either 'tvshow' or 'episode' is considered a tv show.
+    :param media_type_str: The media type string
+    :return: True if the media type is a tv show, False otherwise
+    """
+    return media_type_str == 'tvshow' or media_type_str == 'episode'
+
+def is_movie(media_type_str):
+    """
+    Check if the media type is a movie.
+    :param media_type_str: The media type string
+    :return: True if the media type is a movie, False otherwise
+    """
+    return media_type_str == 'movie'
+
+def get_media_type(player):
+    """
+    Get the media type of the currently playing video. Returns None if no video is playing or the media type is unknown.
+    :param player: The player object
+    :return: The media type of the currently playing video or None if no video is playing or the media type is unknown
+    """
+    if not player.isPlayingVideo():
+        return None
+
+    playing_item = player.getPlayingItem()
+
+    if not playing_item:
+        return None
+
+    video_info_tag = playing_item.getVideoInfoTag()
+
+    if not video_info_tag:
+        return None
+
+    return video_info_tag.getMediaType()

--- a/resources/lib/langcodes.py
+++ b/resources/lib/langcodes.py
@@ -54,6 +54,8 @@ LANGUAGES      = (
     ("Turkish"                    , "30",       "tr",            "tur",                 "42",                    30243  ),
     ("Ukrainian"                  , "46",       "uk",            "ukr",                 "43",                    30244  ),
     ("Vietnamese"                 , "51",       "vi",            "vie",                 "44",                    30245  ),
+    ("English Middle"             , "2",        "",              "enm",                 "47",                    30248  ),
+    ("Norwegian Bokmal"           , "3",        "nb",            "nob",                 "48",                    30249  ),
     ("None"                       , "-1",       "",              "non",                 "45",                    30200  ),
     ("Any"                        , "-2",       "",              "any",                 "46",                    30300  ) )
 

--- a/resources/lib/langcodes.py
+++ b/resources/lib/langcodes.py
@@ -26,7 +26,7 @@ LANGUAGES      = (
     ("Finnish"                    , "31",       "fi",            "fin",                 "14",                    30215  ),
     ("French"                     , "8",        "fr",            "fre",                 "15",                    30216  ),
     ("German"                     , "5",        "de",            "ger,deu",             "16",                    30217  ),
-    ("Greek"                      , "16",       "el",            "ell",                 "17",                    30218  ),
+    ("Greek"                      , "16",       "el",            "ell,gre",             "17",                    30218  ),
     ("Hebrew"                     , "22",       "he",            "heb",                 "18",                    30219  ),
     ("Hindi"                      , "42",       "hi",            "hin",                 "19",                    30220  ),
     ("Hungarian"                  , "15",       "hu",            "hun",                 "20",                    30221  ),

--- a/resources/lib/langcodes.py
+++ b/resources/lib/langcodes.py
@@ -56,6 +56,7 @@ LANGUAGES      = (
     ("Vietnamese"                 , "51",       "vi",            "vie",                 "44",                    30245  ),
     ("English Middle"             , "2",        "",              "enm",                 "47",                    30248  ),
     ("Norwegian Bokmal"           , "3",        "nb",            "nob",                 "48",                    30249  ),
+    ("New Norwegian"              , "3",        "nn",            "nno",                 "49",                    30250  ),
     ("None"                       , "-1",       "",              "non",                 "45",                    30200  ),
     ("Any"                        , "-2",       "",              "any",                 "46",                    30300  ) )
 

--- a/resources/lib/langcodes.py
+++ b/resources/lib/langcodes.py
@@ -45,7 +45,7 @@ LANGUAGES      = (
     ("Portuguese (Brazil)"        , "48",       "pb",            "pt-br",               "33",                    30234  ),
     ("Romanian"                   , "13",       "ro",            "rum",                 "34",                    30235  ),
     ("Russian"                    , "27",       "ru",            "rus",                 "35",                    30236  ),
-    ("Serbian"                    , "36",       "sr",            "scc",                 "36",                    30237  ),
+    ("Serbian"                    , "36",       "sr",            "srp,scc",             "36",                    30237  ),
     ("Slovak"                     , "37",       "sk",            "slo",                 "37",                    30238  ),
     ("Slovenian"                  , "1",        "sl",            "slv",                 "38",                    30239  ),
     ("Spanish"                    , "28",       "es",            "spa",                 "39",                    30240  ),

--- a/resources/lib/logger.py
+++ b/resources/lib/logger.py
@@ -1,0 +1,28 @@
+import xbmc, xbmcaddon
+from prefsettings import settings
+
+LOG_NONE = 0
+LOG_ERROR = 1
+LOG_INFO = 2
+LOG_DEBUG = 3
+
+settings = settings()
+
+def log(level, msg):
+    log_level = settings.logLevel
+
+    if level <= log_level:
+        if level == LOG_ERROR:
+            kodi_log_level = xbmc.LOGERROR
+        elif level == LOG_INFO:
+            kodi_log_level = xbmc.LOGINFO
+        elif level == LOG_DEBUG:
+            kodi_log_level = xbmc.LOGDEBUG
+        else:
+            log(LOG_ERROR, "Unknown log level " + str(level))
+            log(LOG_INFO, msg)
+            return
+
+        xbmc.log("[Language Preference Manager]: " + str(msg), kodi_log_level)
+
+log(LOG_ERROR, "Loading logger.py")

--- a/resources/lib/prefparser.py
+++ b/resources/lib/prefparser.py
@@ -31,7 +31,6 @@ class PrefParser:
         self.custom_g_t_pref_delim = r'#'
         self.custom_g_t_delim = r','
         self.custom_condSub_delim = r':'
-        self.custom_subtag_delim = r'-'
         
     def parsePrefString(self, pref_string):
         preferences = []
@@ -81,17 +80,11 @@ class PrefParser:
                 else:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
                     # Searching if a sub tag is present (like Eng:Eng-ss to prioritize Signs&Songs tracks)
-                    ss_tag = 'false'
-                    if (pref[1].find(self.custom_subtag_delim) > 0):
-                        st_pref = pref[1].split(self.custom_subtag_delim)
-                        if len(st_pref) != 2:
-                            print('Custom cond subs prefs parse error: {0}'.format(pref))
-                        else:
-                            if (st_pref[1] == 'ss'):
-                                ss_tag = 'true'
-                            else:
-                                self.log(LOG_INFO, 'Custom cond subs prefs parse error: {0}. Unknown sub tag is ignored'.format(pref))
-                        pref[1] = st_pref[0]
+                    if pref[1].endswith('-ss'):
+                        ss_tag = 'true'
+                        pref[1] = pref[1].rstrip('-ss')
+                    else:
+                        ss_tag = 'false'
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
                         if (temp_s[1] == 'non'):

--- a/resources/lib/prefparser.py
+++ b/resources/lib/prefparser.py
@@ -31,6 +31,7 @@ class PrefParser:
         self.custom_g_t_pref_delim = r'#'
         self.custom_g_t_delim = r','
         self.custom_condSub_delim = r':'
+        self.custom_subtag_delim = r'-'
         
     def parsePrefString(self, pref_string):
         preferences = []
@@ -79,13 +80,25 @@ class PrefParser:
                             self.log(LOG_INFO, 'Custom cond subs prefs parse error: {0}'.format(pref))
                 else:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
+                    # Searching if a sub tag is present (like Eng:Eng-ss to prioritize Signs&Songs tracks)
+                    ss_tag = 'false'
+                    if (pref[1].find(self.custom_subtag_delim) > 0):
+                        st_pref = pref[1].split(self.custom_subtag_delim)
+                        if len(st_pref) != 2:
+                            print('Custom cond subs prefs parse error: {0}'.format(pref))
+                        else:
+                            if (st_pref[1] == 'ss'):
+                                ss_tag = 'true'
+                            else:
+                                self.log(LOG_INFO, 'Custom cond subs prefs parse error: {0}. Unknown sub tag is ignored'.format(pref))
+                        pref[1] = st_pref[0]
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
                         if (temp_s[1] == 'non'):
                             forced_tag = 'true'
                         else:
                             forced_tag = 'false'
-                        lang_prefs.append((temp_a[0], temp_a[1], temp_s[0], temp_s[1], forced_tag))
+                        lang_prefs.append((temp_a[0], temp_a[1], temp_s[0], temp_s[1], forced_tag, ss_tag))
                     else:
                         self.log(LOG_INFO, 'Custom cond sub prefs: lang code not found in db!'\
                                  ' Please report this: {0}:{1}'.format(temp_a, temp_s))

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -65,7 +65,9 @@ class settings():
                          self.useFilename, self.filenameRegex, self.at_least_one_pref_on,
                          self.AudioPrefs, self.SubtitlePrefs, self.CondSubtitlePrefs,
                          self.custom_audio, self.custom_subs, self.custom_condsub, self.ignore_signs_on,
-                         ','.join(self.keyword_blacklist))
+                         ','.join(self.subtitle_keyword_blacklist),
+                         ','.join(self.audio_keyword_blacklist)
+                        )
                  )
       
     def readPrefs(self):
@@ -79,12 +81,18 @@ class settings():
       self.turn_subs_on = addon.getSetting('turnSubsOn') == 'true'
       self.turn_subs_off = addon.getSetting('turnSubsOff') == 'true'
       self.ignore_signs_on = addon.getSetting('signs') == 'true'
-      self.keyword_blacklist_enabled = addon.getSetting('enableKeywordBlacklist') == 'true'
-      self.keyword_blacklist = addon.getSetting('KeywordBlacklist')
-      if self.keyword_blacklist and self.keyword_blacklist_enabled:
-          self.keyword_blacklist = self.keyword_blacklist.lower().split(',')
+      self.subtitle_keyword_blacklist_enabled = addon.getSetting('enableSubtitleKeywordBlacklist') == 'true'
+      self.subtitle_keyword_blacklist = addon.getSetting('SubtitleKeywordBlacklist')
+      if self.subtitle_keyword_blacklist and self.subtitle_keyword_blacklist_enabled:
+          self.subtitle_keyword_blacklist = self.subtitle_keyword_blacklist.lower().split(',')
       else:
-          self.keyword_blacklist = []
+          self.subtitle_keyword_blacklist = []
+      self.audio_keyword_blacklist_enabled = addon.getSetting('enableAudioKeywordBlacklist') == 'true'
+      self.audio_keyword_blacklist = addon.getSetting('AudioKeywordBlacklist')
+      if self.audio_keyword_blacklist and self.audio_keyword_blacklist_enabled:
+          self.audio_keyword_blacklist = self.audio_keyword_blacklist.lower().split(',')
+      else:
+          self.audio_keyword_blacklist = []
       self.useFilename = addon.getSetting('useFilename') == 'true'
       self.filenameRegex = addon.getSetting('filenameRegex')
       if self.useFilename:

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -96,6 +96,8 @@ class settings():
                                   or self.condsub_prefs_on
                                   or self.useFilename)
       
+      self.CondSubTag = 'false'
+      
       self.AudioPrefs = [(set(), [
           (languageTranslate(addon.getSetting('AudioLang01'), 4, 0) ,
            languageTranslate(addon.getSetting('AudioLang01'), 4, 3)),
@@ -121,21 +123,24 @@ class settings():
               languageTranslate(addon.getSetting('CondAudioLang01'), 4, 3),
               languageTranslate(addon.getSetting('CondSubLang01'), 4, 0),
               languageTranslate(addon.getSetting('CondSubLang01'), 4, 3),
-              addon.getSetting('CondSubForced01')
+              addon.getSetting('CondSubForced01'),
+              self.CondSubTag
           ),
           (
               languageTranslate(addon.getSetting('CondAudioLang02'), 4, 0),
               languageTranslate(addon.getSetting('CondAudioLang02'), 4, 3),
               languageTranslate(addon.getSetting('CondSubLang02'), 4, 0),
               languageTranslate(addon.getSetting('CondSubLang02'), 4, 3),
-              addon.getSetting('CondSubForced02')
+              addon.getSetting('CondSubForced02'),
+              self.CondSubTag
           ),
           (
               languageTranslate(addon.getSetting('CondAudioLang03'), 4, 0),
               languageTranslate(addon.getSetting('CondAudioLang03'), 4, 3),
               languageTranslate(addon.getSetting('CondSubLang03'), 4, 0),
               languageTranslate(addon.getSetting('CondSubLang03'), 4, 3),
-              addon.getSetting('CondSubForced03')
+              addon.getSetting('CondSubForced03'),
+              self.CondSubTag
           )]
       )]
 

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -155,6 +155,7 @@ class settings():
           )]
       )]
 
+      # These handle custom user preferences, that should be stored
       self.movieOverrides = addon.getSetting('movieOverrides') == 'true'
       self.tvShowOverrides = addon.getSetting('tvShowOverrides') == 'true'
       self.storeCustomMediaPreferences = self.movieOverrides or self.tvShowOverrides
@@ -190,21 +191,30 @@ class settings():
         if len(self.custom_condsub) >0:
             self.custom_condsub_prefs_on = True
 
-    def is_store_override_player(self, player):
+    def is_store_user_preference_for_player(self, player):
+        """
+        Check if the player is playing a video and if the store user preference is enabled for the media type of the video (e.g. movie, tv show).
+        :param player: The player object
+        :return: True if the player is playing a video and the store user preference is enabled for the media type, False otherwise
+        """
         if not player.isPlayingVideo():
             return False
 
-        return self.is_store_override(kodi_utils.get_media_type(player))
+        return self.is_store_user_preference(kodi_utils.get_media_type(player))
 
-    def is_store_override(self, media_type):
+    def is_store_user_preference(self, media_type):
+        """
+        Check if the user preference is supposed to be stored. That means that the custom preferences are stored for the media type.
+        :param media_type:  The media type string
+        :return: True if the user preference is supposed to be stored, False otherwise
+        """
         if media_type is None:
             return False
 
-        self.log(LOG_INFO, 'is_store_override: {0}'.format(media_type))
         if kodi_utils.is_movie(media_type):
-            self.log(LOG_INFO, 'is_store_override: {0}'.format(self.movieOverrides))
+            self.log(LOG_DEBUG, 'Store user preference for movie: {0}'.format(self.movieOverrides))
             return self.movieOverrides
         elif kodi_utils.is_tv_show(media_type):
-            self.log(LOG_INFO, 'is_store_override: {0}'.format(self.tvShowOverrides))
+            self.log(LOG_DEBUG, 'Store user preference for tv show: {0}'.format(self.tvShowOverrides))
             return self.tvShowOverrides
         return False

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -50,7 +50,9 @@ class settings():
                  'cond subs on: {3}\n' \
                  'turn subs on: {4}, turn subs off: {5}\n' \
                  'signs: {15}\n' \
-                 'blacklisted keywords: {16}\n' \
+                 'blacklisted keywords (subtitles): {16}\n' \
+                 'blacklisted keywords (audio): {17}\n' \
+                 'fast subtitles display (10sec latency workaround): {18}\n' \
                  'use file name: {6}, file name regex: {7}\n' \
                  'at least one pref on: {8}\n'\
                  'audio prefs: {9}\n' \
@@ -66,7 +68,8 @@ class settings():
                          self.AudioPrefs, self.SubtitlePrefs, self.CondSubtitlePrefs,
                          self.custom_audio, self.custom_subs, self.custom_condsub, self.ignore_signs_on,
                          ','.join(self.subtitle_keyword_blacklist),
-                         ','.join(self.audio_keyword_blacklist)
+                         ','.join(self.audio_keyword_blacklist),
+                         self.fast_subs_display
                         )
                  )
       
@@ -93,6 +96,7 @@ class settings():
           self.audio_keyword_blacklist = self.audio_keyword_blacklist.lower().split(',')
       else:
           self.audio_keyword_blacklist = []
+      self.fast_subs_display = int(addon.getSetting('FastSubsDisplay'))
       self.useFilename = addon.getSetting('useFilename') == 'true'
       self.filenameRegex = addon.getSetting('filenameRegex')
       if self.useFilename:

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -55,6 +55,7 @@ class LangPrefMan_Player(xbmc.Player) :
             log(LOG_DEBUG, 'Getting video properties')
             self.getDetails()
             self.evalPrefs()
+            self.LPM_initial_run_done = True
 
     def onAVChange(self):
         if self.LPM_initial_run_done and settings.service_enabled and settings.at_least_one_pref_on and self.isPlayingVideo():

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -204,7 +204,8 @@ class LangPrefMan_Player(xbmc.Player) :
             if g_t and (not (self.genres_and_tags & g_t)):
                 continue
 
-            log(LOG_INFO,'Audio: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
+            if g_t:
+                log(LOG_INFO,'Audio: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
                 name, codes = pref
                 codes = codes.split(r',')
@@ -243,7 +244,8 @@ class LangPrefMan_Player(xbmc.Player) :
             if g_t and (not (self.genres_and_tags & g_t)):
                 continue
 
-            log(LOG_INFO,'Subtitle: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
+            if g_t:
+                log(LOG_INFO,'Subtitle: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
                 if len(pref) == 2:
                     name, codes = pref
@@ -296,7 +298,8 @@ class LangPrefMan_Player(xbmc.Player) :
             if g_t and (not (self.genres_and_tags & g_t)):
                 continue
 
-            log(LOG_INFO,'Cond Sub: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
+            if g_t:
+                log(LOG_INFO,'Cond Sub: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
                 audio_name, audio_codes, sub_name, sub_codes, forced, ss_tag = pref
                 # manage multiple audio and/or subtitle 3-letters codes if present (ex. German = ger,deu)

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -56,7 +56,7 @@ class LangPrefMan_Player(xbmc.Player) :
             self.getDetails()
             self.evalPrefs()
             # force immediate rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-            self.seekTime(-1)
+            self.seekTime(0)
             self.LPM_initial_run_done = True
 
     def onAVChange(self):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -55,6 +55,8 @@ class LangPrefMan_Player(xbmc.Player) :
             log(LOG_DEBUG, 'Getting video properties')
             self.getDetails()
             self.evalPrefs()
+            # force immediate rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
+            self.seekTime(-1)
             self.LPM_initial_run_done = True
 
     def onAVChange(self):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -75,7 +75,9 @@ class LangPrefMan_Player(xbmc.Player) :
 
                 if custom_preference is not None:
                     log(LOG_INFO, 'Custom media preferences found for current media - Applying them...')
-                    custom_preference.apply_to_player(self)
+                    if not custom_preference.apply_to_player(self):
+                        log(LOG_INFO, 'Failed to apply custom media preferences for current media. Falling back to default preferences...')
+                        self.evalPrefs()
                 else:
                     self.evalPrefs()
             else:
@@ -103,7 +105,7 @@ class LangPrefMan_Player(xbmc.Player) :
 
             log(LOG_INFO, 'Subtitle enabled: {0}'.format(self.selected_sub_enabled))
 
-            if (self.selected_audio_stream['index'] != previous_audio_index):
+            if self.selected_audio_stream['index'] != previous_audio_index:
                 log(LOG_INFO, 'Audio track changed from {0} to {1}. Reviewing Conditional Subtitles rules...'.format(previous_audio_language, self.selected_audio_stream['language']))
 
                 if settings.is_store_user_preference_for_player(self):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -245,7 +245,11 @@ class LangPrefMan_Player(xbmc.Player) :
 
             log(LOG_INFO,'Subtitle: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
-                name, codes, forced = pref
+                if len(pref) == 2:
+                    name, codes = pref
+                    forced = 'false'
+                else:
+                    name, codes, forced = pref
                 codes = codes.split(r',')
                 for code in codes:
                     if (code is None):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -56,7 +56,11 @@ class LangPrefMan_Player(xbmc.Player) :
             self.getDetails()
             self.evalPrefs()
             # force short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-            self.seekTime(self.getTime()-1)
+            # but if we are very close to beginning, then restart from time 0
+            if (self.getTime() <= 10):
+                self.seekTime(0)
+            else:
+                self.seekTime(self.getTime()-1)
             self.LPM_initial_run_done = True
 
     def onAVChange(self):
@@ -73,8 +77,12 @@ class LangPrefMan_Player(xbmc.Player) :
             if (self.selected_audio_stream['index'] != previous_audio_index):
                 log(LOG_INFO, 'Audio track changed from {0} to {1}. Reviewing Conditional Subtitles rules...'.format(previous_audio_language, self.selected_audio_stream['language']))
                 self.evalPrefs()
-                # force short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-                self.seekTime(self.getTime()-1)
+                # force very short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
+                # but if we are very close to beginning, then restart from time 0
+                if (self.getTime() <= 10):
+                    self.seekTime(0)
+                else:
+                    self.seekTime(self.getTime()-1)
     
     def evalPrefs(self):
         # recognized filename audio or filename subtitle

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -270,7 +270,7 @@ class LangPrefMan_Player(xbmc.Player) :
 
             log(LOG_INFO,'Cond Sub: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
-                audio_name, audio_code, sub_name, sub_code, forced = pref
+                audio_name, audio_code, sub_name, sub_code, forced, ss_tag = pref
                 if (audio_code is None):
                     log(LOG_DEBUG,'continue')
                     continue 
@@ -294,6 +294,10 @@ class LangPrefMan_Player(xbmc.Player) :
                             return -1
                         else:
                             for sub in self.subtitles:
+                                if ((sub_code == sub['language']) or (sub_name == sub['language'])):
+                                    if (ss_tag == 'true' and self.isSignsSub(sub['name'])):
+                                        log(LOG_INFO, 'Language of subtitle {0} matches conditional preference {1} ({2}:{3}) SubTag {4}'.format((sub['index']+1), i, audio_name, sub_name, ss_tag) )
+                                        return sub['index']
                                 if (settings.keyword_blacklist_enabled and any(keyword in sub['name'].lower() for keyword in settings.keyword_blacklist)):
                                     log(LOG_INFO,'CondSubs : one subtitle track is found matching Keyword Blacklist : {0}. Skipping it.'.format(','.join(settings.keyword_blacklist)))
                                     continue
@@ -301,7 +305,7 @@ class LangPrefMan_Player(xbmc.Player) :
                                     log(LOG_INFO,'CondSubs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
                                     continue
                                 if ((sub_code == sub['language']) or (sub_name == sub['language'])):
-                                    if (self.testForcedFlag(forced, sub['name'], sub['isforced'])):
+                                    if (ss_tag == 'false' and self.testForcedFlag(forced, sub['name'], sub['isforced'])):
                                         log(LOG_INFO, 'Language of subtitle {0} matches conditional preference {1} ({2}:{3}) forced {4}'.format((sub['index']+1), i, audio_name, sub_name, forced) )
                                         return sub['index']
                             log(LOG_INFO, 'Conditional subtitle: no match found for preference {0} ({1}:{2})'.format(i, audio_name, sub_name) )

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -55,8 +55,8 @@ class LangPrefMan_Player(xbmc.Player) :
             log(LOG_DEBUG, 'Getting video properties')
             self.getDetails()
             self.evalPrefs()
-            # force immediate rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-            self.seekTime(0)
+            # force short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
+            self.seekTime(self.getTime()-1)
             self.LPM_initial_run_done = True
 
     def onAVChange(self):

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -317,7 +317,7 @@ class LangPrefMan_Player(xbmc.Player) :
         test = subName.lower()
         matches = ['forced', 'forcés']
         found = any(x in test for x in matches)
-        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'true')
+        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'True')
 
     def isExternalSub(self, subName):
         test = subName.lower()

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -317,7 +317,12 @@ class LangPrefMan_Player(xbmc.Player) :
         test = subName.lower()
         matches = ['forced', 'forcés']
         found = any(x in test for x in matches)
-        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag) or ((forced == 'false') and not subForcedTag)
+        # Only when looking for forced subs :
+        #   in case the sub name is plain empty or not well documented, 
+        #   check also the sub isforced tag and consider it a match if set
+        if (forced and not found and subForcedTag):
+            found = True
+        return ((forced == 'false') and not found) or ((forced == 'true') and found)
 
     def isExternalSub(self, subName):
         test = subName.lower()

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -317,7 +317,7 @@ class LangPrefMan_Player(xbmc.Player) :
         test = subName.lower()
         matches = ['forced', 'forcés']
         found = any(x in test for x in matches)
-        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'True')
+        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'True') or ((forced == 'false') and subForcedTag == 'False')
 
     def isExternalSub(self, subName):
         test = subName.lower()

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -55,13 +55,6 @@ class LangPrefMan_Player(xbmc.Player) :
             log(LOG_DEBUG, 'Getting video properties')
             self.getDetails()
             self.evalPrefs()
-            # force short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-            # but if we are very close to beginning, then restart from time 0
-            if (self.getTime() <= 10):
-                self.seekTime(0)
-            else:
-                self.seekTime(self.getTime()-1)
-            self.LPM_initial_run_done = True
 
     def onAVChange(self):
         if self.LPM_initial_run_done and settings.service_enabled and settings.at_least_one_pref_on and self.isPlayingVideo():
@@ -77,12 +70,6 @@ class LangPrefMan_Player(xbmc.Player) :
             if (self.selected_audio_stream['index'] != previous_audio_index):
                 log(LOG_INFO, 'Audio track changed from {0} to {1}. Reviewing Conditional Subtitles rules...'.format(previous_audio_language, self.selected_audio_stream['language']))
                 self.evalPrefs()
-                # force very short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
-                # but if we are very close to beginning, then restart from time 0
-                if (self.getTime() <= 10):
-                    self.seekTime(0)
-                else:
-                    self.seekTime(self.getTime()-1)
     
     def evalPrefs(self):
         # recognized filename audio or filename subtitle
@@ -162,6 +149,14 @@ class LangPrefMan_Player(xbmc.Player) :
                     log(LOG_DEBUG, 'Subtitle: enabling subs' )
                     self.showSubtitles(True)
 
+        # Workaround to an old Kodi bug creating 10-15 sec latency when activating a subtitle track.
+        # Force very short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
+        #       but if we are very close to beginning, then restart from time 0        
+        if (self.getTime() <= 10):
+            self.seekTime(0)
+        else:
+            self.seekTime(self.getTime()-1)
+
     def evalFilenamePrefs(self):
         log(LOG_DEBUG, 'Evaluating filename preferences' )
         audio = -1
@@ -237,7 +232,7 @@ class LangPrefMan_Player(xbmc.Player) :
                         continue 
                     if (self.selected_sub and
                         'language' in self.selected_sub and
-                        ((code == self.selected_sub['language'] or name == self.selected_sub['language']) and self.testForcedFlag(forced, self.selected_sub['name']))):
+                        ((code == self.selected_sub['language'] or name == self.selected_sub['language']) and self.testForcedFlag(forced, self.selected_sub['name'], self.selected_sub['isforced']))):
                             log(LOG_INFO, 'Selected subtitle language matches preference {0} ({1})'.format(i, name) )
                             return -1
                     else:
@@ -248,7 +243,7 @@ class LangPrefMan_Player(xbmc.Player) :
                             if (settings.ignore_signs_on and self.isSignsSub(sub['name'])):
                                 log(LOG_INFO,'SubPrefs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
                                 continue
-                            if ((code == sub['language'] or name == sub['language']) and self.testForcedFlag(forced, sub['name'])):
+                            if ((code == sub['language'] or name == sub['language']) and self.testForcedFlag(forced, sub['name'], sub['isforced'])):
                                 log(LOG_INFO, 'Subtitle language of subtitle {0} matches preference {1} ({2})'.format((sub['index']+1), i, name) )
                                 return sub['index']
                         log(LOG_INFO, 'Subtitle: preference {0} ({1}:{2}) not available'.format(i, name, code) )
@@ -290,7 +285,7 @@ class LangPrefMan_Player(xbmc.Player) :
                                     log(LOG_DEBUG, 'Looping subtitles...')
                                     if ((audio_code == sub['language']) or (audio_name == sub['language'])):
                                         log(LOG_DEBUG, 'One potential match found...')
-                                        if (self.testForcedFlag(forced, sub['name'])):
+                                        if (self.testForcedFlag(forced, sub['name'], sub['isforced'])):
                                             log(LOG_DEBUG, 'One forced match found...')
                                             log(LOG_INFO, 'Language of subtitle {0} matches audio preference {1} ({2}:{3}) with forced overriding rule {4}'.format((sub['index']+1), i, audio_name, sub_name, forced) )
                                             return sub['index']
@@ -305,7 +300,7 @@ class LangPrefMan_Player(xbmc.Player) :
                                     log(LOG_INFO,'CondSubs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
                                     continue
                                 if ((sub_code == sub['language']) or (sub_name == sub['language'])):
-                                    if (self.testForcedFlag(forced, sub['name'])):
+                                    if (self.testForcedFlag(forced, sub['name'], sub['isforced'])):
                                         log(LOG_INFO, 'Language of subtitle {0} matches conditional preference {1} ({2}:{3}) forced {4}'.format((sub['index']+1), i, audio_name, sub_name, forced) )
                                         return sub['index']
                             log(LOG_INFO, 'Conditional subtitle: no match found for preference {0} ({1}:{2})'.format(i, audio_name, sub_name) )
@@ -317,11 +312,11 @@ class LangPrefMan_Player(xbmc.Player) :
         matches = ['signs']
         return any(x in test for x in matches)
     
-    def testForcedFlag(self, forced, subName):
+    def testForcedFlag(self, forced, subName, subForcedTag):
         test = subName.lower()
         matches = ['forced', 'forcés']
         found = any(x in test for x in matches)
-        return ((forced == 'false') and not found) or ((forced == 'true') and found)
+        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'true')
 
     def isExternalSub(self, subName):
         test = subName.lower()

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -73,6 +73,8 @@ class LangPrefMan_Player(xbmc.Player) :
             if (self.selected_audio_stream['index'] != previous_audio_index):
                 log(LOG_INFO, 'Audio track changed from {0} to {1}. Reviewing Conditional Subtitles rules...'.format(previous_audio_language, self.selected_audio_stream['language']))
                 self.evalPrefs()
+                # force short rewind to avoid 10-15sec delay and first few subtitles lines potentially lost
+                self.seekTime(self.getTime()-1)
     
     def evalPrefs(self):
         # recognized filename audio or filename subtitle

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -317,7 +317,7 @@ class LangPrefMan_Player(xbmc.Player) :
         test = subName.lower()
         matches = ['forced', 'forcés']
         found = any(x in test for x in matches)
-        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag == 'True') or ((forced == 'false') and subForcedTag == 'False')
+        return ((forced == 'false') and not found) or ((forced == 'true') and found) or ((forced == 'true') and subForcedTag) or ((forced == 'false') and not subForcedTag)
 
     def isExternalSub(self, subName):
         test = subName.lower()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -921,12 +921,12 @@
             </group>
         </category>
         <category id="Overrides" label="30135">
-            <group id="1">
-                <setting id="movieOverrides" type="boolean" label="30136">
+            <group id="6" label="30138">
+                <setting id="movieOverrides" type="boolean" label="30136" help="30139">
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
-                <setting id="tvShowOverrides" type="boolean" label="30137">
+                <setting id="tvShowOverrides" type="boolean" label="30137" help="30139">
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,922 +1,936 @@
 <settings version="1">
-	<section id="service.languagepreferencemanager">
-		<category id="General" label="30122">
-			<group id="1">
-				<setting id="enabled" label="30108" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="log_level" label="Log level" type="integer">
-					<default>1</default>
-					<constraints>
-						<options>
-							<option label="NONE">0</option>
-							<option label="ERROR">1</option>
-							<option label="INFO">2</option>
-							<option label="DEBUG">3</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-			<group id="2" label="30115">
-				<setting id="turnSubsOn" label="30113" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="turnSubsOff" label="30114" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="useFilename" label="30116" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting label="30117" type="string" id="filenameRegex">
-					<default>audiostream[_|.|-]*\d+|subtitle[_|.|-]*\d+</default>
-					<constraints>
-						<allowempty>false</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30117</heading>
-					</control>
-				</setting>
-				<setting id="delay" label="30112" type="integer">
-					<default>300</default>
-					<control type="edit" format="integer">
-						<heading>30112</heading>
-					</control>
-				</setting>
-				<setting id="pause" label="30109" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="signs" label="30123" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="3">
-				<setting id="enableSubtitleKeywordBlacklist" label="30125" type="boolean">
-					<default>false</default>
-					<control type="toggle" />
-				</setting>
-				<setting label="30126" type="string" id="SubtitleKeywordBlacklistLabel">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30126</heading>
-					</control>
-					<enable>false</enable>
-					<dependencies>
-						<dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true</dependency>
-					</dependencies>
-				</setting>
-				<setting label="30127" type="string" id="SubtitleKeywordBlacklist">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30127</heading>
-					</control>
-					<dependencies>
-						<dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true</dependency>
-					</dependencies>
-				</setting>
-			</group>
-			<group id="4">
-				<setting id="enableAudioKeywordBlacklist" label="30128" type="boolean">
-					<default>false</default>
-					<control type="toggle" />
-				</setting>
-				<setting label="30129" type="string" id="AudioKeywordBlacklistLabel">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30129</heading>
-					</control>
-					<enable>false</enable>
-					<dependencies>
-						<dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
-					</dependencies>
-				</setting>
-				<setting label="30130" type="string" id="AudioKeywordBlacklist">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30130</heading>
-					</control>
-					<dependencies>
-						<dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
-					</dependencies>
-				</setting>
-			</group>
-			<group id="5">
-				<setting id="FastSubsDisplay" type="integer" label="30131">
-					<default>0</default>
-					<constraints>
-						<options>
-							<option label="30132">0</option>
-							<option label="30133">1</option>
-							<option label="30134">2</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-		</category>
-		<category id="Audio Preferences" label="30104">
-			<group id="1">
-				<setting id="enableAudio" label="30107" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="2">
-				<setting id="AudioLang01" type="integer" label="30101">
-					<default>15</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-			<group id="3">
-				<setting id="AudioLang02" type="integer" label="30102">
-					<default>11</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>							
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-			<group id="4">
-				<setting id="AudioLang03" type="integer" label="30103">
-					<default>45</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-			</group>
-			<group id="5">
-				<setting label="30118" type="string" id="CustomAudio">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30118</heading>
-					</control>
-				</setting>
-			</group>
-		</category>
-		<category id="Subtitle Preferences" label="30105">
-			<group id="1">
-				<setting id="enableSub" label="30107" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="2">
-				<setting id="SubLang01" type="integer" label="30101">
-					<default>15</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="SubForced01" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="3">
-				<setting id="SubLang02" type="integer" label="30102">
-					<default>11</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="SubForced02" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="4">
-				<setting id="SubLang03" type="integer" label="30103">
-					<default>45</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="SubForced03" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="5">
-				<setting label="30119" type="string" id="CustomSub">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30119</heading>
-					</control>
-				</setting>
-			</group>
-		</category>
-		<category id= "Conditional Subtitle Preferences" label="30106">
-			<group id="1">
-				<setting id="enableCondSub" label="30107" type="boolean">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="2">
-				<setting id="CondAudioLang01" type="integer" label="30110">
-					<default>15</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-							<option label="30300">46</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="CondSubLang01" type="integer" label="30111">
-					<default>45</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting> 
-				<setting id="CondSubForced01" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="3">
-				<setting id="CondAudioLang02" type="integer" label="30110">
-					<default>11</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-							<option label="30300">46</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="CondSubLang02" type="integer" label="30111">
-					<default>15</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="CondSubForced02" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="4">
-				<setting id="CondAudioLang03" type="integer" label="30110">
-					<default>11</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-							<option label="30300">46</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="CondSubLang03" type="integer" label="30111">
-					<default>11</default>
-					<constraints>
-						<options>
-							<option label="30201">0</option>
-							<option label="30202">1</option>
-							<option label="30203">2</option>
-							<option label="30204">3</option>
-							<option label="30205">4</option>
-							<option label="30206">5</option>
-							<option label="30207">6</option>
-							<option label="30208">7</option>
-							<option label="30209">8</option>
-							<option label="30210">9</option>
-							<option label="30211">10</option>
-							<option label="30212">11</option>
-							<option label="30213">12</option>
-							<option label="30214">13</option>
-							<option label="30215">14</option>
-							<option label="30216">15</option>
-							<option label="30217">16</option>
-							<option label="30218">17</option>
-							<option label="30219">18</option>
-							<option label="30220">19</option>
-							<option label="30221">20</option>
-							<option label="30222">21</option>
-							<option label="30223">22</option>
-							<option label="30224">23</option>
-							<option label="30225">24</option>
-							<option label="30226">25</option>
-							<option label="30227">26</option>
-							<option label="30228">27</option>
-							<option label="30229">28</option>
-							<option label="30230">29</option>
-							<option label="30231">30</option>
-							<option label="30232">31</option>
-							<option label="30233">32</option>
-							<option label="30234">33</option>
-							<option label="30235">34</option>
-							<option label="30236">35</option>
-							<option label="30237">36</option>
-							<option label="30238">37</option>
-							<option label="30239">38</option>
-							<option label="30240">39</option>
-							<option label="30241">40</option>
-							<option label="30242">41</option>
-							<option label="30243">42</option>
-							<option label="30244">43</option>
-							<option label="30245">44</option>
-							<option label="30248">47</option>
-							<option label="30249">48</option>
-							<option label="30250">49</option>
-							<option label="30200">45</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="CondSubForced03" type="boolean" label="30120">
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="5">
-				<setting label="30121" type="string" id="CustomCondSub">
-					<default></default>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="edit" format="string">
-						<heading>30121</heading>
-					</control>
-				</setting>
-			</group>
-		</category>	
-	</section>
+    <section id="service.languagepreferencemanager">
+        <category id="General" label="30122">
+            <group id="1">
+                <setting id="enabled" label="30108" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="log_level" label="Log level" type="integer">
+                    <default>1</default>
+                    <constraints>
+                        <options>
+                            <option label="NONE">0</option>
+                            <option label="ERROR">1</option>
+                            <option label="INFO">2</option>
+                            <option label="DEBUG">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+            <group id="2" label="30115">
+                <setting id="turnSubsOn" label="30113" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="turnSubsOff" label="30114" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="useFilename" label="30116" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting label="30117" type="string" id="filenameRegex">
+                    <default>audiostream[_|.|-]*\d+|subtitle[_|.|-]*\d+</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30117</heading>
+                    </control>
+                </setting>
+                <setting id="delay" label="30112" type="integer">
+                    <default>300</default>
+                    <control type="edit" format="integer">
+                        <heading>30112</heading>
+                    </control>
+                </setting>
+                <setting id="pause" label="30109" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="signs" label="30123" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="3">
+                <setting id="enableSubtitleKeywordBlacklist" label="30125" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting label="30126" type="string" id="SubtitleKeywordBlacklistLabel">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30126</heading>
+                    </control>
+                    <enable>false</enable>
+                    <dependencies>
+                        <dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting label="30127" type="string" id="SubtitleKeywordBlacklist">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30127</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true
+                        </dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="4">
+                <setting id="enableAudioKeywordBlacklist" label="30128" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting label="30129" type="string" id="AudioKeywordBlacklistLabel">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30129</heading>
+                    </control>
+                    <enable>false</enable>
+                    <dependencies>
+                        <dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
+                <setting label="30130" type="string" id="AudioKeywordBlacklist">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30130</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
+            </group>
+            <group id="5">
+                <setting id="FastSubsDisplay" type="integer" label="30131">
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="30132">0</option>
+                            <option label="30133">1</option>
+                            <option label="30134">2</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+        </category>
+        <category id="Audio Preferences" label="30104">
+            <group id="1">
+                <setting id="enableAudio" label="30107" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="2">
+                <setting id="AudioLang01" type="integer" label="30101">
+                    <default>15</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+            <group id="3">
+                <setting id="AudioLang02" type="integer" label="30102">
+                    <default>11</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+            <group id="4">
+                <setting id="AudioLang03" type="integer" label="30103">
+                    <default>45</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+            </group>
+            <group id="5">
+                <setting label="30118" type="string" id="CustomAudio">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30118</heading>
+                    </control>
+                </setting>
+            </group>
+        </category>
+        <category id="Subtitle Preferences" label="30105">
+            <group id="1">
+                <setting id="enableSub" label="30107" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="2">
+                <setting id="SubLang01" type="integer" label="30101">
+                    <default>15</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="SubForced01" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="3">
+                <setting id="SubLang02" type="integer" label="30102">
+                    <default>11</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="SubForced02" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="4">
+                <setting id="SubLang03" type="integer" label="30103">
+                    <default>45</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="SubForced03" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="5">
+                <setting label="30119" type="string" id="CustomSub">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30119</heading>
+                    </control>
+                </setting>
+            </group>
+        </category>
+        <category id="Conditional Subtitle Preferences" label="30106">
+            <group id="1">
+                <setting id="enableCondSub" label="30107" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="2">
+                <setting id="CondAudioLang01" type="integer" label="30110">
+                    <default>15</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                            <option label="30300">46</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubLang01" type="integer" label="30111">
+                    <default>45</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubForced01" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="3">
+                <setting id="CondAudioLang02" type="integer" label="30110">
+                    <default>11</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                            <option label="30300">46</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubLang02" type="integer" label="30111">
+                    <default>15</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubForced02" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="4">
+                <setting id="CondAudioLang03" type="integer" label="30110">
+                    <default>11</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                            <option label="30300">46</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubLang03" type="integer" label="30111">
+                    <default>11</default>
+                    <constraints>
+                        <options>
+                            <option label="30201">0</option>
+                            <option label="30202">1</option>
+                            <option label="30203">2</option>
+                            <option label="30204">3</option>
+                            <option label="30205">4</option>
+                            <option label="30206">5</option>
+                            <option label="30207">6</option>
+                            <option label="30208">7</option>
+                            <option label="30209">8</option>
+                            <option label="30210">9</option>
+                            <option label="30211">10</option>
+                            <option label="30212">11</option>
+                            <option label="30213">12</option>
+                            <option label="30214">13</option>
+                            <option label="30215">14</option>
+                            <option label="30216">15</option>
+                            <option label="30217">16</option>
+                            <option label="30218">17</option>
+                            <option label="30219">18</option>
+                            <option label="30220">19</option>
+                            <option label="30221">20</option>
+                            <option label="30222">21</option>
+                            <option label="30223">22</option>
+                            <option label="30224">23</option>
+                            <option label="30225">24</option>
+                            <option label="30226">25</option>
+                            <option label="30227">26</option>
+                            <option label="30228">27</option>
+                            <option label="30229">28</option>
+                            <option label="30230">29</option>
+                            <option label="30231">30</option>
+                            <option label="30232">31</option>
+                            <option label="30233">32</option>
+                            <option label="30234">33</option>
+                            <option label="30235">34</option>
+                            <option label="30236">35</option>
+                            <option label="30237">36</option>
+                            <option label="30238">37</option>
+                            <option label="30239">38</option>
+                            <option label="30240">39</option>
+                            <option label="30241">40</option>
+                            <option label="30242">41</option>
+                            <option label="30243">42</option>
+                            <option label="30244">43</option>
+                            <option label="30245">44</option>
+                            <option label="30248">47</option>
+                            <option label="30249">48</option>
+                            <option label="30250">49</option>
+                            <option label="30200">45</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string"/>
+                </setting>
+                <setting id="CondSubForced03" type="boolean" label="30120">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+            <group id="5">
+                <setting label="30121" type="string" id="CustomCondSub">
+                    <default></default>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30121</heading>
+                    </control>
+                </setting>
+            </group>
+        </category>
+        <category id="Overrides" label="30135">
+            <group id="1">
+                <setting id="movieOverrides" type="boolean" label="30136">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="tvShowOverrides" type="boolean" label="30137">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
+        </category>
+    </section>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -189,6 +189,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -245,6 +247,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>							
 						</options>
 					</constraints>
@@ -301,6 +305,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -376,6 +382,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -436,6 +444,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -496,6 +506,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -575,6 +587,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -630,6 +644,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -690,6 +706,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -745,6 +763,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -805,6 +825,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -860,6 +882,8 @@
 							<option label="30243">42</option>
 							<option label="30244">43</option>
 							<option label="30245">44</option>
+							<option label="30248">47</option>
+							<option label="30249">48</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -57,11 +57,11 @@
 				</setting>
 			</group>
 			<group id="3">
-				<setting id="enableKeywordBlacklist" label="30125" type="boolean">
+				<setting id="enableSubtitleKeywordBlacklist" label="30125" type="boolean">
 					<default>false</default>
 					<control type="toggle" />
 				</setting>
-				<setting label="30126" type="string" id="KeywordBlacklistLabel">
+				<setting label="30126" type="string" id="SubtitleKeywordBlacklistLabel">
 					<default></default>
 					<constraints>
 						<allowempty>true</allowempty>
@@ -71,10 +71,10 @@
 					</control>
 					<enable>false</enable>
 					<dependencies>
-						<dependency type="visible" setting="enableKeywordBlacklist" operator="is">true</dependency>
+						<dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true</dependency>
 					</dependencies>
 				</setting>
-				<setting label="30127" type="string" id="KeywordBlacklist">
+				<setting label="30127" type="string" id="SubtitleKeywordBlacklist">
 					<default></default>
 					<constraints>
 						<allowempty>true</allowempty>
@@ -83,7 +83,38 @@
 						<heading>30127</heading>
 					</control>
 					<dependencies>
-						<dependency type="visible" setting="enableKeywordBlacklist" operator="is">true</dependency>
+						<dependency type="visible" setting="enableSubtitleKeywordBlacklist" operator="is">true</dependency>
+					</dependencies>
+				</setting>
+			</group>
+			<group id="4">
+				<setting id="enableAudioKeywordBlacklist" label="30128" type="boolean">
+					<default>false</default>
+					<control type="toggle" />
+				</setting>
+				<setting label="30129" type="string" id="AudioKeywordBlacklistLabel">
+					<default></default>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="edit" format="string">
+						<heading>30129</heading>
+					</control>
+					<enable>false</enable>
+					<dependencies>
+						<dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
+					</dependencies>
+				</setting>
+				<setting label="30130" type="string" id="AudioKeywordBlacklist">
+					<default></default>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="edit" format="string">
+						<heading>30130</heading>
+					</control>
+					<dependencies>
+						<dependency type="visible" setting="enableAudioKeywordBlacklist" operator="is">true</dependency>
 					</dependencies>
 				</setting>
 			</group>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -118,6 +118,19 @@
 					</dependencies>
 				</setting>
 			</group>
+			<group id="5">
+				<setting id="FastSubsDisplay" type="integer" label="30131">
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="30132">0</option>
+							<option label="30133">1</option>
+							<option label="30134">2</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+			</group>
 		</category>
 		<category id="Audio Preferences" label="30104">
 			<group id="1">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -191,6 +191,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -249,6 +250,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>							
 						</options>
 					</constraints>
@@ -307,6 +309,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -384,6 +387,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -446,6 +450,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -508,6 +513,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -589,6 +595,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -646,6 +653,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -708,6 +716,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -765,6 +774,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>
@@ -827,6 +837,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 							<option label="30300">46</option>
 						</options>
@@ -884,6 +895,7 @@
 							<option label="30245">44</option>
 							<option label="30248">47</option>
 							<option label="30249">48</option>
+							<option label="30250">49</option>
 							<option label="30200">45</option>
 						</options>
 					</constraints>


### PR DESCRIPTION
**EDIT:**

This PR is based on the 1.0.5 branch and newest changes. Maybe master should be updated to be in line with the newest release?
Otherwise I can create a separate request to push to the 1.0.5 branch.

-------------------------------------------------

Added feature described in my forum post.
Separate option for movies and series added, that if enabled have the following effect:

If the user changes the audio or subtitle track this preference will be stored, if the option is enabled for media category. That means subtitle lang code + index and audio lang code + index are stored. Lang code is prefered when "restoring" at a later point.
These custom selections are restored if:

**TV Series:** Playing the same show. 
-> Assuming, for example, I am watching an episode of a show with two audio tracks: _Jap and Eng_. This addon is configured to prefer Jap over Eng. 
  
However, if I enabled the new option and I manually change over to the english audio track and disable subtitles, this is stored. Next time I play any episode from the same tv show -> The manually selected settings are preferably restored instead of the default behaviour. In this example _"Eng audio track, no subtitles"_. If for some reason the lang code/index cannot be found in a different episode during playback, default behaviour applies.

**Movie:** Same File (name). Same as TV Show, just that it will only be stored for the examt same file.

I tried to apply modern coding standards and documentation to my code. The old code left in this addon could need a cleanup at some point.

I tried to touch as little of existing code as possible.

**Known Issue rn:**
Can't figure out how to track subtitle changes separately, since AVChange only triggers during audio change. If you have a suggestion on how to tackle this, feel free


