### PR TITLE
Avoid running multiple instances of the LPM addon

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.7Beta3"
+	version="1.0.7Beta4"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -20,12 +20,13 @@
 		<disclaimer lang="en_GB">For bugs, requests or general questions visit the Language Preference Manager thread on the Kodi forum.</disclaimer>
 		<disclaimer lang="sv_SE">För buggar, önskemål eller allmänna frågor, besök tråden Language Preference Manager på Kodi-forumet.</disclaimer>
 		<platform>all</platform>
-		<news>1.0.7Beta2 : - New option to always prefer Original audio tracks if present. Based on a list e.g: eng,ger,fre
+		<news>1.0.7Beta4 : - New option to always prefer Original audio tracks if present. Based on a list e.g: eng,ger,fre
 	If one is found we force activate it and skip usual audio preference evaluation. Uses 'isoriginal' tag.
 - Add Swedish translation in Addon.xml (Thanks to Yeager)
 - Fix minor bug in settings.xml, display error in subtitles keywords blacklist settings menu
 - Custom Conditional Subs preferences : new -ff tag to prioritize Forced flagged subtitles e.g: Jpn:Eng-ff
 - Fix a bug in Custom Conditional Subs : when no preference matched, default subtitles stays on despite option turn_subs_off
+- Avoid running multiple instances of the LPM addon
 			
 		</news>
 		<assets>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
---- Version 1.0.7Beta3
+--- Version 1.0.7Beta4
 
 - New option to always prefer Original audio tracks if present. Based on a list e.g: eng,ger,fre
 	If one is found we force activate it and skip usual audio preference evaluation. Uses 'isoriginal' tag.
@@ -6,6 +6,7 @@
 - Fix minor bug in settings.xml, display error in subtitles keywords blacklist settings menu
 - Custom Conditional Subs preferences : new -ff tag to prioritize Forced flagged subtitles e.g : ...>Jpn:Eng-ff>...
 - Fix a bug in Custom Conditional Subs : when no preference matched, default subtitles stays on despite option turn_subs_off
+- Avoid running multiple instances of the LPM addon
 
 --- Version 1.0.6
 

--- a/default.py
+++ b/default.py
@@ -1,5 +1,5 @@
 import os, sys, re
-import xbmc, xbmcaddon, xbmcvfs, xmbcgui
+import xbmc, xbmcaddon, xbmcvfs, xbmcgui
 
 import json as simplejson
 

--- a/default.py
+++ b/default.py
@@ -1,5 +1,5 @@
 import os, sys, re
-import xbmc, xbmcaddon, xbmcvfs
+import xbmc, xbmcaddon, xbmcvfs, xmbcgui
 
 import json as simplejson
 

--- a/default.py
+++ b/default.py
@@ -59,6 +59,11 @@ class Main:
 if len(sys.argv) > 1 and sys.argv[1] == 'show_overrides':
     from resources.lib.override_preference_dialog import *
 elif __name__ == "__main__":
-    log(LOG_INFO, 'service {0} version {1} started'.format(__addonname__, __addonversion__))
-    main = Main()
-    log(LOG_INFO, 'service {0} version {1} stopped'.format(__addonname__, __addonversion__))
+    if xbmcgui.Window(10000).getProperty(__addonid__ + '_isrunning') == 'True':
+        log(LOG_INFO, 'service {0} version {1} is already started. Doing nothing.'.format(__addonname__, __addonversion__))
+    else:
+        xbmcgui.Window(10000).setProperty(__addonid__ + '_isrunning', 'True')
+        log(LOG_INFO, 'service {0} version {1} started'.format(__addonname__, __addonversion__))
+        main = Main()
+        xbmcgui.Window(10000).setProperty(__addonid__ + '_isrunning', 'False')
+        log(LOG_INFO, 'service {0} version {1} stopped'.format(__addonname__, __addonversion__))


### PR DESCRIPTION

Block LPM from running multiple instances to avoid duplicated preferences analysis