### PR TITLE
2.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,21 @@
+--- Version 2.0
+
+- feat: Add regex-based subtitle stream selector with fallback support
+- Added new toggle "Use regex pattern to filter subtitles" in General settings
+- Added editable regex pattern field (conditionally visible when toggle is enabled)
+- New evalRegexSubPrefs() method scans all subtitle streams and selects first match
+- Runs early in evalPrefs() before normal subtitle preferences
+- Falls back to Conditional Subtitle Preferences if no regex match found
+- Sets use_filename_subs flag to prevent subsequent prefs from overriding matched track
+- Added error handling for invalid regex patterns
+- Updated strings.po with two new label entries (#30146, #30147)
+
+--- Version 1.0.8
+
+- Fix addon not closing properly when "Store Preferences" is used
+(Kodi exit : freeze on Piers, thread error message on Omega)
+- Handle exception error in case video player reports no current audiostream activated
+
 --- Version 1.0.7
 
 - New option to always prefer Original audio tracks if present. Based on a list e.g: eng,ger,fre

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -193,6 +193,14 @@ msgctxt "#30144"
 msgid "Audio Original Preference List:"
 msgstr ""
 
+msgctxt "#30146"
+msgid "Use regex pattern to filter subtitles"
+msgstr ""
+
+msgctxt "#30147"
+msgid "Regex pattern for subtitle filtering"
+msgstr ""
+
 msgctxt "#30201"
 msgid "Albanian"
 msgstr ""

--- a/resources/lib/prefsettings.py
+++ b/resources/lib/prefsettings.py
@@ -37,6 +37,7 @@ class settings():
                  'cond subs on: {3}\n' \
                  'turn subs on: {4}, turn subs off: {5}\n' \
                  'signs: {15}\n' \
+                 'regex sub filter: {20}\n' \
                  'blacklisted keywords (subtitles): {16}\n' \
                  'blacklisted keywords (audio): {17}\n' \
                  'audio original pref list: {19}\n' \
@@ -58,7 +59,8 @@ class settings():
                          ','.join(self.subtitle_keyword_blacklist),
                          ','.join(self.audio_keyword_blacklist),
                          self.fast_subs_display,
-                         ','.join(self.audio_original_preflist)
+                         ','.join(self.audio_original_preflist),
+                         self.regex_sub_filter_enabled
                         )
                  )
       
@@ -79,6 +81,16 @@ class settings():
       self.turn_subs_on = addon.getSetting('turnSubsOn') == 'true'
       self.turn_subs_off = addon.getSetting('turnSubsOff') == 'true'
       self.ignore_signs_on = addon.getSetting('signs') == 'true'
+      self.regex_sub_filter_enabled = addon.getSetting('regexSubFilter') == 'true'
+      self.regex_sub_pattern = addon.getSetting('regexSubPattern')
+      if self.regex_sub_filter_enabled and self.regex_sub_pattern:
+          try:
+              self.regex_sub_filter = re.compile(self.regex_sub_pattern)
+          except re.error as e:
+              log(LOG_ERROR, 'Invalid regex pattern: {0} - {1}'.format(self.regex_sub_pattern, str(e)))
+              self.regex_sub_filter = None
+      else:
+          self.regex_sub_filter = None
       self.subtitle_keyword_blacklist_enabled = addon.getSetting('enableSubtitleKeywordBlacklist') == 'true'
       self.subtitle_keyword_blacklist = addon.getSetting('SubtitleKeywordBlacklist')
       if self.subtitle_keyword_blacklist and self.subtitle_keyword_blacklist_enabled:
@@ -97,7 +109,6 @@ class settings():
       if self.useFilename:
           self.reg = re.compile(self.filenameRegex, re.IGNORECASE)
           self.split = re.compile(r'[_|.|-]*', re.IGNORECASE)
-
 
       
       self.CondSubTag = 'false'

--- a/resources/lib/prefutils.py
+++ b/resources/lib/prefutils.py
@@ -14,7 +14,6 @@ from prefsettings import settings
 
 settings = settings()
 
-
 class LangPref_Monitor(xbmc.Monitor):
 
     def __init__(self):
@@ -23,7 +22,6 @@ class LangPref_Monitor(xbmc.Monitor):
     def onSettingsChanged(self):
         settings.init()
         settings.readSettings()
-
 
 class LangPrefWatcher(threading.Thread):
     """
@@ -55,7 +53,6 @@ class LangPrefWatcher(threading.Thread):
         """ Method to stop the thread gracefully """
         self._stop_event.set()
         self.join()
-
 
 class LangPrefMan_Player(xbmc.Player):
 
@@ -219,6 +216,18 @@ class LangPrefMan_Player(xbmc.Player):
         use_filename_audio = False
         use_filename_subs = False
 
+        # Regex-based subtitle selection — runs before normal subtitle preferences
+        if settings.regex_sub_filter_enabled and not self.LPM_initial_run_done:
+            regex_sub_index = self.evalRegexSubPrefs()
+            if regex_sub_index >= 0:
+                self.setSubtitleStream(regex_sub_index)
+                use_filename_subs = True  # Prevent normal sub prefs from overriding
+                if settings.turn_subs_on:
+                    log(LOG_INFO, 'Regex subtitle: enabling subs')
+                    self.showSubtitles(True)
+            else:
+                log(LOG_INFO, 'Regex subtitle: No match found, falling back to normal subtitle preferences')
+
         if settings.useFilename and not self.LPM_initial_run_done:
             audio, sub = self.evalFilenamePrefs()
             if (audio >= 0) and audio < len(self.audiostreams):
@@ -349,6 +358,29 @@ class LangPrefMan_Player(xbmc.Player):
 
         return -1
 
+    def evalRegexSubPrefs(self):
+        """
+        Evaluate regex subtitle preferences. Scan all subtitle streams and find
+        the first one whose name matches the configured regex pattern.
+        Returns the subtitle track index if a match is found, -2 if no match.
+        """
+        log(LOG_DEBUG, 'Evaluating regex subtitle preferences')
+        if not settings.regex_sub_filter_enabled or settings.regex_sub_filter is None:
+            return -2
+
+        for sub in self.subtitles:
+            sub_name = sub.get('name', '')
+            try:
+                if settings.regex_sub_filter.search(sub_name):
+                    log(LOG_INFO, 'Regex subtitle preference: Match found - selecting subtitle track {0} ({1})'.format(
+                        sub['index'], sub_name))
+                    return sub['index']
+            except Exception as e:
+                log(LOG_ERROR, 'Regex search error on subtitle "{0}": {1}'.format(sub_name, str(e)))
+
+        log(LOG_INFO, 'Regex subtitle preference: No matching subtitle track found')
+        return -2
+
     def evalFilenamePrefs(self):
         log(LOG_DEBUG, 'Evaluating filename preferences')
         audio = -1
@@ -476,7 +508,7 @@ class LangPrefMan_Player(xbmc.Player):
                                     'SubPrefs : one subtitle track is found matching Keyword Blacklist : {0}. Skipping it.'.format(
                                         ','.join(settings.subtitle_keyword_blacklist)))
                                 continue
-                            if (settings.ignore_signs_on and self.isSignsSub(sub['name'])):
+                            if settings.ignore_signs_on and self.isSignsSub(sub['name']):
                                 log(LOG_INFO,
                                     'SubPrefs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
                                 continue
@@ -582,14 +614,6 @@ class LangPrefMan_Player(xbmc.Player):
                                     # Consider empty subtitle language code as und/Undefined so it can still be prioritized in rules, not just ignored
                                     if sub['language'] == "":
                                         sub['language'] = "und"
-                                    # take into account -ss tag to prioritize specific Signs&Songs subtitles track
-                                    if (sub_code == sub['language']) or (sub_name == sub['language']):
-                                        if ss_tag == 'true' and self.isSignsSub(sub['name']):
-                                            log(LOG_INFO,
-                                                'CondSubs : Language of subtitle {0} matches conditional preference {1} ({2}:{3}) SubTag {4}'.format(
-                                                    (sub['index'] + 1), i, audio_name, sub_name, ss_tag))
-                                            to_chose_subtitle_indexes.append(sub['index'])
-                                            # return sub['index']
                                     # filter out subtitles to be ignored via Signs&Songs Toggle or matching Keywords Blacklist
                                     if self.isInBlacklist(sub['name'], 'Subtitle'):
                                         log(LOG_INFO,
@@ -600,6 +624,14 @@ class LangPrefMan_Player(xbmc.Player):
                                         log(LOG_INFO,
                                             'CondSubs : ignore_signs toggle is on and one such subtitle track is found. Skipping it.')
                                         continue
+                                    # take into account -ss tag to prioritize specific Signs&Songs subtitles track
+                                    if (sub_code == sub['language']) or (sub_name == sub['language']):
+                                        if ss_tag == 'true' and self.isSignsSub(sub['name']):
+                                            log(LOG_INFO,
+                                                'CondSubs : Language of subtitle {0} matches conditional preference {1} ({2}:{3}) SubTag {4}'.format(
+                                                    (sub['index'] + 1), i, audio_name, sub_name, ss_tag))
+                                            to_chose_subtitle_indexes.append(sub['index'])
+                                            # return sub['index']
                                     if (sub_code == sub['language']) or (sub_name == sub['language']):
                                         if (ss_tag == 'false' and self.testForcedFlag(forced, sub['name'],
                                                                                       sub['isforced'])):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -55,6 +55,22 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
+                <setting id="regexSubFilter" label="30146" type="boolean">
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+                <setting label="30147" type="string" id="regexSubPattern">
+                    <default>(?i:s[\s._+\-\/\\]*(?:&amp;|\+)?[\s._+\-\/\\]*s|forced|foreign|songs?|signs?|only|non|parts?|titles?|alien|navi|dothraki)</default>
+                    <constraints>
+                        <allowempty>false</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>30147</heading>
+                    </control>
+                    <dependencies>
+                        <dependency type="visible" setting="regexSubFilter" operator="is">true</dependency>
+                    </dependencies>
+                </setting>
             </group>
             <group id="3">
                 <setting id="enableSubtitleKeywordBlacklist" label="30125" type="boolean">
@@ -838,7 +854,6 @@
                             <option label="30210">9</option>
                             <option label="30211">10</option>
                             <option label="30212">11</option>
-                            <option label="30213">12</option>
                             <option label="30214">13</option>
                             <option label="30215">14</option>
                             <option label="30216">15</option>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -854,6 +854,7 @@
                             <option label="30210">9</option>
                             <option label="30211">10</option>
                             <option label="30212">11</option>
+                            <option label="30213">12</option>        
                             <option label="30214">13</option>
                             <option label="30215">14</option>
                             <option label="30216">15</option>


### PR DESCRIPTION
changelog.txt: 
  - feat: Add regex-based subtitle stream selector with fallback support
  - Added ability to automatically select subtitle tracks matching a custom regex
pattern, falling back to Conditional Subtitle Preferences if no match found.

settings.xml: 
  - Add regex subtitle filter toggle and pattern input
  - Added boolean setting 'regexSubFilter' (ID 30146)
  - Added string setting 'regexSubPattern' (ID 30147) with default pattern
  - Pattern field depends on toggle being enabled

prefsettings.py: 
  - Load and compile regex pattern from settings
  - Read settings in readPrefs(), compile regex object on startup
  - Added try/except for invalid regex patterns

prefutils.py: 
  - Implement regex subtitle selector with fallback logic
  - evalRegexSubPrefs() scans subtitle streams for pattern match
  - Runs early in evalPrefs() before normal preferences
  - Sets use_filename_subs flag to prevent override by later prefs
  - Falls through to Conditional Subtitle Preferences if no match

strings.po:
  - Add UI labels for new regex subtitle settings
  - #30146: Toggle label
  - #30147: Pattern input label
